### PR TITLE
add ability to use Fx importer for pytorch to torch MLIR 

### DIFF
--- a/e2eshark/pytorch/combinations/mlp/model.py
+++ b/e2eshark/pytorch/combinations/mlp/model.py
@@ -23,3 +23,8 @@ test_input = torch.randn(8, 3)
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+test_torchmlir = None

--- a/e2eshark/pytorch/models/dlrm/model.py
+++ b/e2eshark/pytorch/models/dlrm/model.py
@@ -310,8 +310,7 @@ class DLRM_Net(nn.Module):
             # single device run
             return self.sequential_forward(dense_x, lS_o, lS_i)
         else:
-            # single-node multi-device run
-            return self.parallel_forward(dense_x, lS_o, lS_i)
+            print("Only single device run is support.")
 
     def sequential_forward(self, dense_x, lS_o, lS_i):
         # process dense features (using bottom mlp), resulting in a row vector
@@ -529,8 +528,6 @@ model.eval()
 
 print(f"INFO: Running inference using fx graph to generate reference data...")
 test_output = model(batch_dense_X, batch_lS_o, batch_lS_i)
-
-
 sorted, indices = torch.sort(test_output, dim=0, descending=True)
 top_n = batch_size if batch_size < 5 else 5
 print(f"INFO: Clickthrough probability of top {top_n} ads:")
@@ -544,3 +541,9 @@ for i in range(top_n):
 
 print("Input:", test_input)
 print("Onput:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+# Force usage of torch_mlir.compile
+test_torchmlir = "compile"

--- a/e2eshark/pytorch/models/llama2-7b-hf/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-hf/model.py
@@ -8,12 +8,17 @@ modelname = "meta-llama/Llama-2-7b-hf"
 
 tokenizer = LlamaTokenizer.from_pretrained(modelname)
 model = LlamaForCausalLM.from_pretrained(
-    modelname, low_cpu_mem_usage=True, attn_implementation="eager"
+    modelname,
+    low_cpu_mem_usage=True,
+    attn_implementation="eager",
+    torchscript=True,
 )
 model.to("cpu")
+model.eval()
+model.output_hidden_states = False
 prompt = "What is nature of our existence?"
-batch = tokenizer(prompt, return_tensors="pt")
-test_input = batch["input_ids"].cpu()
+encoding = tokenizer(prompt, return_tensors="pt")
+test_input = encoding["input_ids"].cpu()
 test_output = model.generate(
     test_input,
     do_sample=True,
@@ -22,7 +27,13 @@ test_output = model.generate(
     top_p=0.95,
     temperature=1.0,
 )[0]
+attention_mask = encoding["attention_mask"]
 print("Prompt:", prompt)
 print("Response:", tokenizer.decode(test_output))
 print("Input:", test_input)
 print("Output:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+test_torchmlir = None

--- a/e2eshark/pytorch/models/opt-125M/model.py
+++ b/e2eshark/pytorch/models/opt-125M/model.py
@@ -18,3 +18,8 @@ test_input = torch.tensor([tokenizer.encode("The test prommpt")])
 test_output = model(test_input)[0]
 print("Input:", test_input)
 print("Output:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+test_torchmlir = None

--- a/e2eshark/pytorch/operators/conv2d/model.py
+++ b/e2eshark/pytorch/operators/conv2d/model.py
@@ -20,3 +20,8 @@ test_input = torch.randn(2, 8, 12, 16)
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+test_torchmlir = None

--- a/e2eshark/pytorch/operators/linear/model.py
+++ b/e2eshark/pytorch/operators/linear/model.py
@@ -18,3 +18,8 @@ test_input = torch.randn(8, 3)
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)
+# Do not enforce any particular strategy for getting torch MLIR
+# By default set it to None, set it to
+# 'compile' : to force using torch_mllir.compile
+# 'fximport' : to force using PyTorch 2.0 Fx Import
+test_torchmlir = None


### PR DESCRIPTION
For some cases, torch_mlir.compile still works better, add ability to override fx importer usage in test case to get maximum number of designs to work