### PR TITLE
uniform way of saving input and gold output 

### DIFF
--- a/e2eshark/README.md
+++ b/e2eshark/README.md
@@ -63,13 +63,16 @@ To get a local build of torch MLIR: https://github.com/llvm/torch-mlir/blob/main
 For torch MLIR build, build the torch_mlir python wheel as well as per:
 https://github.com/llvm/torch-mlir/blob/main/docs/development.md#build-python-packages 
 Edit setup.py to insert following in cmake_args if you used clang to build torch-mlir 
+```
  f"-DCMAKE_C_COMPILER=clang",
  f"-DCMAKE_CXX_COMPILER=clang++",
+ ```
 And then following
+```
 CMAKE_GENERATOR=Ninja python setup.py bdist_wheel --dist-dir ./torch-mlir-wheel -v
 pip uninstall torch-mlir
 pip install torch-mlir-wheel/torch_mlir-0.0.1-cp310-cp310-linux_x86_64.whl
-
+```
 To get a local build of IREE: https://iree.dev/building-from-source/getting-started 
 
 If using AMD AIE target, build https://github.com/nod-ai/iree-amd-aie in addition

--- a/e2eshark/onnx/combinations/constant_constantofshape/model.py
+++ b/e2eshark/onnx/combinations/constant_constantofshape/model.py
@@ -40,19 +40,22 @@ check_model(onnx_model)
 with open("model.onnx", "wb") as f:
     f.write(onnx_model.SerializeToString())
 
-
+# test_input and test_output must be numpy
+# bfloat16 is not supported by onnxruntime and numpy
+# case to/from fp32 to work around at various stages
 # start an onnxrt session
 session = onnxruntime.InferenceSession("model.onnx", None)
-test_input = []
+test_input = numpy.array([])
 inputs = session.get_inputs()
 # This test has no input
 input_name = ""
 # Get the name of the input of the model
 # input_name = inputs.name
 
-
+# TBD: Use iobinding and ortvalue explicitly as per
+# https://onnxruntime.ai/docs/api/python/api_summary.html
 # call inference session
 # test_output = [session.run([], {input_name: test_input})[0]]
-test_output = [session.run([], {})[0]]
+test_output = numpy.array([session.run([], {})[0]], dtype=numpy.int64)
 print("Input:", test_input)
 print("Output:", test_output)

--- a/e2eshark/onnx/models/resnet50/model.py
+++ b/e2eshark/onnx/models/resnet50/model.py
@@ -14,6 +14,9 @@ import onnxruntime
 # start an onnxrt session
 session = onnxruntime.InferenceSession("model.onnx", None)
 
+# test_input and test_output must be numpy
+# bfloat16 is not supported by onnxruntime and numpy
+# case to/from fp32 to work around at various stages
 # fill the lines that set test_input and onnx_output
 # these two are special names and should not be changed
 test_input = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
@@ -21,7 +24,10 @@ print("Input:", test_input)
 
 # Get the name of the input of the model
 input_name = session.get_inputs()[0].name
-
+# TBD: Use iobinding and ortvalue explicitly as per
+# https://onnxruntime.ai/docs/api/python/api_summary.html
 # call inference session
-test_output = [session.run([], {input_name: test_input})[0]]
+test_output = numpy.array(
+    [session.run([], {input_name: test_input})[0]], dtype=numpy.float32
+)
 print("Output:", test_output)

--- a/e2eshark/onnx/models/resnet50_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/resnet50_vaiq_int8/model.py
@@ -14,6 +14,9 @@ import onnxruntime
 # start an onnxrt session
 session = onnxruntime.InferenceSession("model.onnx", None)
 
+# test_input and test_output must be numpy
+# bfloat16 is not supported by onnxruntime and numpy
+# case to/from fp32 to work around at various stages
 # fill the lines that set test_input and onnx_output
 # these two are special names and should not be changed
 test_input = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
@@ -21,7 +24,10 @@ print("Input:", test_input)
 
 # Get the name of the input of the model
 input_name = session.get_inputs()[0].name
-
+# TBD: Use iobinding and ortvalue explicitly as per
+# https://onnxruntime.ai/docs/api/python/api_summary.html
 # call inference session
-test_output = [session.run([], {input_name: test_input})[0]]
+test_output = numpy.array(
+    [session.run([], {input_name: test_input})[0]], dtype=numpy.float32
+)
 print("Output:", test_output)

--- a/e2eshark/tools/stubs/onnxmodel.py
+++ b/e2eshark/tools/stubs/onnxmodel.py
@@ -4,7 +4,7 @@
 import numpy
 import onnxruntime
 import sys, argparse
-
+import torch
 
 msg = "The script to run an ONNX model test"
 parser = argparse.ArgumentParser(description=msg, epilog="")
@@ -33,17 +33,15 @@ dtype = args.dtype
 runmode = args.mode
 outfileprefix = args.outfileprefix
 outfileprefix += "." + dtype
-inputsavefilename = outfileprefix + ".input"
-outputsavefilename = outfileprefix + ".output"
+inputsavefilename = outfileprefix + ".input.pt"
+outputsavefilename = outfileprefix + ".goldoutput.pt"
 
 # test_input and test_output are defined in model.py as numpy array which
 # is prepended to this file
-# numpy does not support bfloat16, cast to fp32 and restore back to
-# bfloat16 in run.py when gotten value from an inference run that supports
-# bfloat16
-if args.dtype == "bf16":
-    test_input = numpy.float32(test_input)
-    test_output = numpy.float32(test_output)
-
-numpy.save(inputsavefilename, test_input)
-numpy.save(outputsavefilename, test_output)
+# to have uniform way to run test
+# same input and output as torch .pt
+pttest_input = torch.from_numpy(test_input)
+pttest_output = torch.from_numpy(test_output)
+print(pttest_input, pttest_output)
+torch.save(pttest_input, inputsavefilename)
+torch.save(pttest_output, outputsavefilename)


### PR DESCRIPTION
uniform way of saving input and gold output using torch.save and applying input to iree-run-module using raw binary to allow bfloat16 handling down the road