### PR TITLE
Opt bf16 debug

### DIFF
--- a/e2eshark/pytorch/combinations/mlp/model.py
+++ b/e2eshark/pytorch/combinations/mlp/model.py
@@ -20,6 +20,8 @@ class mlp(nn.Module):
 
 model = mlp()
 test_input = torch.randn(8, 3)
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)

--- a/e2eshark/pytorch/models/dlrm/model.py
+++ b/e2eshark/pytorch/models/dlrm/model.py
@@ -547,3 +547,4 @@ print("Onput:", test_output)
 # 'fximport' : to force using PyTorch 2.0 Fx Import
 # Force usage of torch_mlir.compile
 test_torchmlircompile = "compile"
+test_modelname = None

--- a/e2eshark/pytorch/models/dlrm/model.py
+++ b/e2eshark/pytorch/models/dlrm/model.py
@@ -517,6 +517,8 @@ for i in range(ln_emb.size):
 # Run the model with the sample query and profiler
 dlrm_ref.eval()
 test_input = [batch_dense_X, batch_lS_o, batch_lS_i]
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = True
 
 # model = make_fx(  # type: ignore[no-untyped-call]
 #    dlrm_ref,

--- a/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
@@ -8,7 +8,7 @@ from transformers import (
     GPTQConfig,
 )
 
-modelname = "TheBloke/Llama-2-7B-GPTQ"
+test_modelname = "TheBloke/Llama-2-7B-GPTQ"
 kwargs = {
     "torch_dtype": torch.float32,
     "trust_remote_code": True,
@@ -17,10 +17,10 @@ quantization_config = GPTQConfig(bits=8, disable_exllama=True)
 kwargs["quantization_config"] = quantization_config
 kwargs["device_map"] = "cpu"
 model = AutoModelForCausalLM.from_pretrained(
-    modelname, low_cpu_mem_usage=True, attn_implementation="eager", **kwargs
+    test_modelname, low_cpu_mem_usage=True, attn_implementation="eager", **kwargs
 )
 # model.output_hidden_states = False
-tokenizer = AutoTokenizer.from_pretrained(modelname)
+tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()

--- a/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
@@ -24,6 +24,8 @@ tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model.generate(
     test_input,
     do_sample=True,

--- a/e2eshark/pytorch/models/llama2-7b-hf/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-hf/model.py
@@ -4,10 +4,10 @@ import torch.nn as nn
 import transformers
 from transformers import LlamaForCausalLM, LlamaTokenizer
 
-modelname = "meta-llama/Llama-2-7b-hf"
-tokenizer = LlamaTokenizer.from_pretrained(modelname)
+test_modelname = "meta-llama/Llama-2-7b-hf"
+tokenizer = LlamaTokenizer.from_pretrained(test_modelname)
 model = LlamaForCausalLM.from_pretrained(
-    modelname,
+    test_modelname,
     low_cpu_mem_usage=True,
     attn_implementation="eager",
     torchscript=True,

--- a/e2eshark/pytorch/models/llama2-7b-hf/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-hf/model.py
@@ -18,6 +18,8 @@ model.output_hidden_states = False
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model.generate(
     test_input,
     do_sample=True,

--- a/e2eshark/pytorch/models/opt-1.3b/model.py
+++ b/e2eshark/pytorch/models/opt-1.3b/model.py
@@ -18,6 +18,8 @@ model.eval()
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = True
 # test_output = model(test_input)[0]
 test_output = model.generate(
     test_input,

--- a/e2eshark/pytorch/models/opt-1.3b/model.py
+++ b/e2eshark/pytorch/models/opt-1.3b/model.py
@@ -4,10 +4,10 @@ import torch.nn as nn
 import torch_mlir
 from transformers import OPTForCausalLM, AutoTokenizer
 
-modelname = "facebook/opt-1.3b"
-tokenizer = AutoTokenizer.from_pretrained(modelname)
+test_modelname = "facebook/opt-1.3b"
+tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 model = OPTForCausalLM.from_pretrained(
-    modelname,
+    test_modelname,
     num_labels=2,
     output_attentions=False,
     output_hidden_states=False,

--- a/e2eshark/pytorch/models/opt-125M/model.py
+++ b/e2eshark/pytorch/models/opt-125M/model.py
@@ -4,10 +4,10 @@ import torch.nn as nn
 import torch_mlir
 from transformers import OPTForCausalLM, AutoTokenizer
 
-modelname = "facebook/opt-125M"
-tokenizer = AutoTokenizer.from_pretrained(modelname)
+test_modelname = "facebook/opt-125M"
+tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 model = OPTForCausalLM.from_pretrained(
-    modelname,
+    test_modelname,
     num_labels=2,
     output_attentions=False,
     output_hidden_states=False,

--- a/e2eshark/pytorch/models/opt-125M/model.py
+++ b/e2eshark/pytorch/models/opt-125M/model.py
@@ -18,6 +18,8 @@ model.eval()
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = True
 # test_output = model(test_input)[0]
 test_output = model.generate(
     test_input,

--- a/e2eshark/pytorch/models/opt-125m-gptq/model.py
+++ b/e2eshark/pytorch/models/opt-125m-gptq/model.py
@@ -19,6 +19,8 @@ tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model.generate(
     test_input,
     do_sample=True,

--- a/e2eshark/pytorch/models/opt-125m-gptq/model.py
+++ b/e2eshark/pytorch/models/opt-125m-gptq/model.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer, GPTQConfig
 
-modelname = "facebook/opt-125m"
+test_modelname = "facebook/opt-125m"
 quantizedmodelname = "jlsilva/facebook-opt-125m-gptq4bit"
 kwargs = {
     "torch_dtype": torch.float32,
@@ -15,7 +15,7 @@ kwargs["quantization_config"] = quantization_config
 kwargs["device_map"] = "cpu"
 model = AutoModelForCausalLM.from_pretrained(quantizedmodelname, **kwargs)
 # model.output_hidden_states = False
-tokenizer = AutoTokenizer.from_pretrained(modelname)
+tokenizer = AutoTokenizer.from_pretrained(test_modelname)
 prompt = "What is nature of our existence?"
 encoding = tokenizer(prompt, return_tensors="pt")
 test_input = encoding["input_ids"].cpu()

--- a/e2eshark/pytorch/models/resnet50/model.py
+++ b/e2eshark/pytorch/models/resnet50/model.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 import torch_mlir
 from torchvision.models import resnet50, ResNet50_Weights
 
+test_modelname = "resnet50"
 weights = ResNet50_Weights.DEFAULT
 model = resnet50(weights=weights)
 model.eval()

--- a/e2eshark/pytorch/models/resnet50/model.py
+++ b/e2eshark/pytorch/models/resnet50/model.py
@@ -10,6 +10,8 @@ model = resnet50(weights=weights)
 model.eval()
 
 test_input = test_input = torch.randn(1, 3, 224, 224)
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)

--- a/e2eshark/pytorch/operators/conv2d/model.py
+++ b/e2eshark/pytorch/operators/conv2d/model.py
@@ -17,6 +17,8 @@ class op_conv2d(nn.Module):
 
 model = op_conv2d()
 test_input = torch.randn(2, 8, 12, 16)
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)

--- a/e2eshark/pytorch/operators/linear/model.py
+++ b/e2eshark/pytorch/operators/linear/model.py
@@ -15,6 +15,8 @@ class op_linear(nn.Module):
 
 model = op_linear()
 test_input = torch.randn(8, 3)
+# Flag to prevent casting of input to a different dtype
+keep_input_dtype = False
 test_output = model(test_input)
 print("Input:", test_input)
 print("Output:", test_output)

--- a/e2eshark/tools/stubs/pytorchmodel.py
+++ b/e2eshark/tools/stubs/pytorchmodel.py
@@ -70,14 +70,12 @@ def getTorchDType(dtypestr):
 
 
 if args.todtype != "default":
+    # convert the model to given dtype
     dtype = getTorchDType(args.todtype)
     model = model.to(dtype)
     # not all model need the input re-casted
-    # add cases for models as needed
-    if test_modelname is not None and \
-       "opt" in test_modelname:
-        pass
-    else:
+    # use `keep_input_dtype` to prevent conversion
+    if not keep_input_dtype:
         test_input = test_input.to(dtype)
     test_output = model(test_input)
 

--- a/e2eshark/tools/stubs/pytorchmodel.py
+++ b/e2eshark/tools/stubs/pytorchmodel.py
@@ -74,7 +74,8 @@ if args.todtype != "default":
     model = model.to(dtype)
     # not all model need the input re-casted
     # add cases for models as needed
-    if "opt" in test_modelname:
+    if test_modelname is not None and \
+       "opt" in test_modelname:
         pass
     else:
         test_input = test_input.to(dtype)

--- a/e2eshark/tools/stubs/utils.py
+++ b/e2eshark/tools/stubs/utils.py
@@ -1,0 +1,13 @@
+# fix model op to be a list of tensors
+# recursively flattens tuple of tuples to a list of single tuples in order
+# example - (1, ((2,3),(4,5),(6,7))) -> [1,2,3,4,5,6,7]
+def getOutputTensorList(test_out):
+    def flatten_tuples(tup):
+        if isinstance(tup, tuple):
+            res = []
+            for t in tup:
+                res.extend(flatten_tuples(t))
+            return res
+        return [tup]
+    test_op_list = flatten_tuples(test_out)
+    return test_op_list


### PR DESCRIPTION
- This PR fixes execution upto OPT-125M Bf16 test running and giving mismatched result
- fix expected output of pytorch model to be a List[Tensor] which earlier was nested tuples 
- fix number of vmfb output mismatch in run-inference
- fix uses test_modelname to skip model input type conversion when importing models of different dtypes also add change for corresponding models