### PR TITLE
add cleanup + uploading features

### DIFF
--- a/e2eshark/gold/upload_list.txt
+++ b/e2eshark/gold/upload_list.txt
@@ -1,4 +1,3 @@
 pytorch/models/beit-base-patch16-224-pt22k-ft22k
 pytorch/models/bge-base-en-v1.5
 pytorch/models/deit-small-distilled-patch16-224
-pytorch/models/bert-large-uncased

--- a/e2eshark/gold/upload_list.txt
+++ b/e2eshark/gold/upload_list.txt
@@ -1,0 +1,4 @@
+pytorch/models/beit-base-patch16-224-pt22k-ft22k
+pytorch/models/bge-base-en-v1.5
+pytorch/models/deit-small-distilled-patch16-224
+pytorch/models/bert-large-uncased

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -9,3 +9,4 @@ tabulate
 # install nightly build of iree-compiler and iree-runtime
 iree-compiler -f https://iree.dev/pip-release-links.html
 iree-runtime -f https://iree.dev/pip-release-links.html
+azure-storage-blob

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -16,11 +16,11 @@ import warnings
 import datetime
 from azure.storage.blob import BlobServiceClient
 import json
+from multiprocessing import Manager
 
 # Need to allow invocation of run.py from anywhere
 sys.path.append(Path(__file__).parent)
 from tools.stubs.commonutils import applyPostProcessPipeline
-from multiprocessing import Manager
 
 def getTestsList(frameworkname, test_types):
     testsList = []

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -118,7 +118,7 @@ def uploadToBlobStorage(file_path, file_name, testName, uploadDict):
 def logAndReturn(commandslog, timelog, resultdict, retval, uploadtestsList, cleanup, testName, uploadDict):
 
     delete_list = ["mlir", "vmfb"]
-    upload_list = ["mlir", "pkl"]
+    upload_list = ["mlir"]
 
     # Loop through everything in folder in current working directory
     if uploadtestsList or cleanup:

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -122,11 +122,11 @@ def logAndReturn(commandslog, timelog, resultdict, retval, uploadtestsList, clea
 
     # Loop through everything in folder in current working directory
     if uploadtestsList or cleanup:
+        dateAndTime = str(datetime.datetime.now(datetime.timezone.utc))
         listOfItems = os.listdir(os.getcwd())
         for item in listOfItems:
             file_type = item.split(".")[-1]
             if testName in uploadtestsList and file_type in upload_list:
-                dateAndTime = str(datetime.datetime.now(datetime.timezone.utc))
                 identifier = testName.replace("/", "_") + "/" + dateAndTime + "/" + item
                 uploadToBlobStorage(os.path.abspath(item), identifier, testName, uploadDict)
             if cleanup:

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -83,19 +83,8 @@ def loadE2eSharkCheckDictionary():
     return e2esharkDict
 
 def uploadToBlobStorage(file_path, file_name, testName, uploadDict):
-    os.environ["AZURE_STORAGE_ACCOUNT_KEY"] = (
-        "XSsr+KqxBLxXzRtFv3QbbdsAxdwDGe661Q1xY4ziMRtpCazN8W6HZePi6nwud5RNLC5Y7e410abg+AStyzmX1A=="
-    )
-    os.environ["AZURE_STORAGE_ACCOUNT_NAME"] = "tankturbine"
-    os.environ["AZURE_CONNECTION_STRING"] = (
-        "DefaultEndpointsProtocol=https;AccountName=tankturbine;AccountKey=XSsr+KqxBLxXzRtFv3QbbdsAxdwDGe661Q1xY4ziMRtpCazN8W6HZePi6nwud5RNLC5Y7e410abg+AStyzmX1A==;EndpointSuffix=core.windows.net"
-    )
-    os.environ["AZURE_CONTAINER_NAME"] = "tankturbine"
-
-    storage_account_key = os.environ.get("AZURE_STORAGE_ACCOUNT_KEY")
-    storage_account_name = os.environ.get("AZURE_STORAGE_ACCOUNT_NAME")
-    connection_string = os.environ.get("AZURE_CONNECTION_STRING")
-    container_name = os.environ.get("AZURE_CONTAINER_NAME")
+    connection_string = "DefaultEndpointsProtocol=https;AccountName=e2esharkuserartifacts;AccountKey=/Bm7PcsKeZOqN5S03R6xJIBgvFMQK06ZddzLMzsFbX+bQ0+RuNseJiaZQVfLpT2V0B61ce+1BUm2+AStFsSVBA==;EndpointSuffix=core.windows.net"
+    container_name = "e2esharkuserartifacts"
 
     blob_service_client = BlobServiceClient.from_connection_string(connection_string)
     blob_client = blob_service_client.get_blob_client(
@@ -112,11 +101,10 @@ def uploadToBlobStorage(file_path, file_name, testName, uploadDict):
             f"model artifacts have already been uploaded for this blob name"
         )
         return
-    # upload to azure storage container tankturbine
+    # upload to azure storage container e2esharkuserartifacts
     with open(file_path, "rb") as data:
         blob_client.upload_blob(data)
     print(f"Uploaded {file_name}.")
-    print(blob_client.url)
     uploadDict[testName] =  blob_client.url
 
 


### PR DESCRIPTION
This commit allows the user to specify cleanup and upload command line options. The cleanup option allows the user to run the tests with space efficiency (removing mlir and vmfb files by default). Which types of files are removed can be changed by the user. Also, there is an uploading feature introduced. This allows the user to specify a list of tests in the `gold/upload_list.txt` file. If the test that the user is running falls in this list, the file types that the user choses are uploaded to an Azure space. They are organized here with unique identifier based on test name + date + UTC time so we won't try uploading to the same name. Also, after running the suite, a `upload_urls.txt` file is created. In this file, you can find a mapping of the test name to Azure link. This way the user doesn't have to deal with Azure. More details can be found in code.