### PR TITLE
Adding tolerance parameters --atol and --rtol to run.py script

### DIFF
--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -465,11 +465,11 @@ def runCodeGeneration(
 #    fp32: atol=1e-05, rtol=1.3e-06
 def getTolerances(args, torchdtype):
     if args.atol != False and args.rtol != False:
-        return (float(args.atol) , float(args.rtol))
+        return (float(args.atol), float(args.rtol))
     elif args.atol != False:
-        return (float(args.atol) , 1e-03)
+        return (float(args.atol), 1e-03)
     elif args.rtol != False:
-        return (1e-03, float(args.rtol))    
+        return (1e-03, float(args.rtol))
     elif torchdtype == torch.bfloat16:
         return (1e-02, 1e-01)
     elif torchdtype == torch.float16:

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -459,21 +459,14 @@ def runCodeGeneration(
 
 # ∣input−other∣ ≤ atol + rtol × ∣other∣
 # returns (atol, rtol)
-# Pytorch torch.testing defaults:
-#    bf16: atol=1e-05, rtol=1.6e-02
-#    fp16: atol=1e-05, rtol=1e-03
-#    fp32: atol=1e-05, rtol=1.3e-06
-def getTolerances(args, torchdtype):
-    if args.atol != False and args.rtol != False:
+# Pytorch torch.testing:
+def getTolerances(args):
+    if args.atol and args.rtol:
         return (float(args.atol), float(args.rtol))
-    elif args.atol != False:
+    elif args.atol:
         return (float(args.atol), 1e-03)
-    elif args.rtol != False:
+    elif args.rtol:
         return (1e-03, float(args.rtol))
-    elif torchdtype == torch.bfloat16:
-        return (1e-02, 1e-01)
-    elif torchdtype == torch.float16:
-        return (1e-04, 1e-03)
     else:
         return (1e-04, 1e-04)
 
@@ -491,7 +484,7 @@ def compareOutputs(args, goldoutput, infoutput, dtype):
             # If each element matches exactly only then torch.equal is true
             inferencematched = torch.equal(infoutput, goldoutput)
         else:
-            atol, rtol = getTolerances(args, dtype)
+            atol, rtol = getTolerances(args)
             inferencematched = torch.allclose(infoutput, goldoutput, rtol, atol)
     return inferencematched
 
@@ -1352,12 +1345,12 @@ def main():
     parser.add_argument(
         "--rtol",
         help="Set rtol tolerance parameter",
-        default=False,
+        type=float,
     )
     parser.add_argument(
         "--atol",
         help="Set atol tolerance parameter",
-        default=False,
+        type=float,
     )
 
     args = parser.parse_args()

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -461,14 +461,7 @@ def runCodeGeneration(
 # returns (atol, rtol)
 # Pytorch torch.testing:
 def getTolerances(args):
-    if args.atol and args.rtol:
-        return (float(args.atol), float(args.rtol))
-    elif args.atol:
-        return (float(args.atol), 1e-03)
-    elif args.rtol:
-        return (1e-03, float(args.rtol))
-    else:
-        return (1e-04, 1e-04)
+    return (args.atol, args.rtol)
 
 def compareOutputs(args, goldoutput, infoutput, dtype):
     # if shapes do not match, we have a problem as comparison routines may crash
@@ -1346,11 +1339,13 @@ def main():
         "--rtol",
         help="Set rtol tolerance parameter",
         type=float,
+        default=1e-04,
     )
     parser.add_argument(
         "--atol",
         help="Set atol tolerance parameter",
         type=float,
+        default=1e-04,
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Parameters added to provide tolerances for comparing the test results.
--atol
--rtol 

For example: 
python ./run.py -c /home/ubuntu/E2E_MLIR_IREE/TORCH_MLIR/torch-mlir_main_af/build -i /home/ubuntu/E2E_MLIR_IREE/IREE/iree-build --report --cachedir /home/ubuntu/E2E_MLIR_IREE/CacheDir --tests pytorch/models/opt-1.3b --atol 1e-03 --rtol 1e-03
