### PR TITLE
Rework iree_tests to keep going after compile XPASS.

### DIFF
--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -324,8 +324,8 @@ class IreeCompileRunItem(pytest.Item):
         try:
             self.test_compile()
         except IreeCompileException as e:
+            # Note: Fallthrough for XPASS (no exception but expected failure).
             if not self.spec.expect_compile_success:
-                # Note: XPASS falls through to after self.test_run() below.
                 self.add_marker(
                     pytest.mark.xfail(
                         raises=IreeCompileException,
@@ -336,6 +336,14 @@ class IreeCompileRunItem(pytest.Item):
             raise e
 
         if self.spec.skip_run:
+            if not self.spec.expect_compile_success:
+                self.add_marker(
+                    pytest.mark.xfail(
+                        raises=IreeCompileException,
+                        strict=True,
+                        reason="Expected compilation to fail (skipped run)",
+                    )
+                )
             return
 
         if not self.spec.expect_run_success:


### PR DESCRIPTION
If a test unexpectedly passes the compilation phase, this now keeps going and tests the runtime. Depending on the outcome, a specific message is logged allowing for easier updating of config files. Updating is still a manual process, but it now requires less moving test cases back and forth between XFAIL lists.

Sample logs:
```
________ IREE compile and run: test_averagepool_2d_precomputed_strides::cpu_llvm_sync_test ________ [gw20] win32 -- Python 3.11.2 D:\dev\projects\SHARK-TestSuite\iree_tests\nightly_pip.venv\Scripts\python.exe
[XPASS(strict)] Expected compile to fail (remove from 'expected_compile_failures')
```

```
___ IREE compile and run: test_dynamicquantizelinear_min_adjusted_expanded::cpu_llvm_sync_test ____ [gw50] win32 -- Python 3.11.2 D:\dev\projects\SHARK-TestSuite\iree_tests\nightly_pip.venv\Scripts\python.exe
Expected compile failure but run failed (move to 'expected_run_failures'):
Error invoking iree-run-module
Error code: 1
Stderr diagnostics:

Stdout diagnostics:
EXEC @test_dynamicquantizelinear_min_adjusted_expanded
[FAILED] result[0]: metadata is 3x4xi8; expected that the view matches 3x4xui8; expected that the view is equal to contents of a view of 3x4xui8
  expected:
3x4xui8=[64 134 83 159][213 255 96 166][249 255 191 149]
  actual:
3x4xi8=[64 -122 83 -97][-43 -1 96 -90][-7 -1 -65 -107]
[FAILED] result[2]: metadata is i8; expected that the view matches ui8; expected that the view is equal to contents of a view of ui8
  expected:
ui8=0
  actual:
i8=0

Compiled with:
  cd D:\dev\projects\SHARK-TestSuite\iree_tests\onnx\node\generated\test_dynamicquantizelinear_min_adjusted_expanded && iree-compile model.mlir --iree-hal-target-backends=llvm-cpu -o model_cpu_llvm_sync_test.vmfb

Run with:
  cd D:\dev\projects\SHARK-TestSuite\iree_tests\onnx\node\generated\test_dynamicquantizelinear_min_adjusted_expanded && iree-run-module --module=model_cpu_llvm_sync_test.vmfb --device=local-sync --flagfile=test_data_flags.txt
```