### PR TITLE
Add `, Inc.` to copyright comments.

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/combinations/constant_constantofshape/model.py
+++ b/e2eshark/onnx/combinations/constant_constantofshape/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/combinations/mlp/model.py
+++ b/e2eshark/onnx/combinations/mlp/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/CumSum/model.py
+++ b/e2eshark/onnx/operators/CumSum/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/DynamicQuantizeLinear/model.py
+++ b/e2eshark/onnx/operators/DynamicQuantizeLinear/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/DynamicQuantizeLinearCast/model.py
+++ b/e2eshark/onnx/operators/DynamicQuantizeLinearCast/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/GatherND/model.py
+++ b/e2eshark/onnx/operators/GatherND/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/LogSoftmax/model.py
+++ b/e2eshark/onnx/operators/LogSoftmax/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/LogSoftmaxOld/model.py
+++ b/e2eshark/onnx/operators/LogSoftmaxOld/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/MatMul/model.py
+++ b/e2eshark/onnx/operators/MatMul/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Mul/model.py
+++ b/e2eshark/onnx/operators/Mul/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Pow/model.py
+++ b/e2eshark/onnx/operators/Pow/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Shape/model.py
+++ b/e2eshark/onnx/operators/Shape/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Sigmoid/model.py
+++ b/e2eshark/onnx/operators/Sigmoid/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Softmax/model.py
+++ b/e2eshark/onnx/operators/Softmax/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/Unsqueeze/model.py
+++ b/e2eshark/onnx/operators/Unsqueeze/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/add/model.py
+++ b/e2eshark/onnx/operators/add/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/concat/model.py
+++ b/e2eshark/onnx/operators/concat/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/equal/model.py
+++ b/e2eshark/onnx/operators/equal/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/expand/model.py
+++ b/e2eshark/onnx/operators/expand/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/flatten/model.py
+++ b/e2eshark/onnx/operators/flatten/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/gelu/model.py
+++ b/e2eshark/onnx/operators/gelu/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/gemm/model.py
+++ b/e2eshark/onnx/operators/gemm/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/gemm2/model.py
+++ b/e2eshark/onnx/operators/gemm2/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/identity/model.py
+++ b/e2eshark/onnx/operators/identity/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/layernorm/model.py
+++ b/e2eshark/onnx/operators/layernorm/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/maxpool/model.py
+++ b/e2eshark/onnx/operators/maxpool/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/neg/model.py
+++ b/e2eshark/onnx/operators/neg/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/reduceprod/model.py
+++ b/e2eshark/onnx/operators/reduceprod/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/relu/model.py
+++ b/e2eshark/onnx/operators/relu/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/onnx/operators/reshape/model.py
+++ b/e2eshark/onnx/operators/reshape/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/combinations/mlp/model.py
+++ b/e2eshark/pytorch/combinations/mlp/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/bart-large/model.py
+++ b/e2eshark/pytorch/models/bart-large/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/beit-base-patch16-224-pt22k-ft22k/model.py
+++ b/e2eshark/pytorch/models/beit-base-patch16-224-pt22k-ft22k/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/bert-large-uncased/model.py
+++ b/e2eshark/pytorch/models/bert-large-uncased/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
+++ b/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/deit-small-distilled-patch16-224/model.py
+++ b/e2eshark/pytorch/models/deit-small-distilled-patch16-224/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/gpt2-xl/model.py
+++ b/e2eshark/pytorch/models/gpt2-xl/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/gpt2/model.py
+++ b/e2eshark/pytorch/models/gpt2/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
+++ b/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/mit-b0/model.py
+++ b/e2eshark/pytorch/models/mit-b0/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/mobilebert-uncased/model.py
+++ b/e2eshark/pytorch/models/mobilebert-uncased/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/opt-350m/model.py
+++ b/e2eshark/pytorch/models/opt-350m/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/phi-1_5/model.py
+++ b/e2eshark/pytorch/models/phi-1_5/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/phi-2/model.py
+++ b/e2eshark/pytorch/models/phi-2/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
+++ b/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/t5-base/model.py
+++ b/e2eshark/pytorch/models/t5-base/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
@@ -37,11 +37,11 @@ model = T5Model.from_pretrained(
 model.to("cpu")
 model.eval()
 tokenizer("Studies have been shown that owning a dog is good for you", **tokenization_kwargs)
-encoded_input_ids = tokenizer("Studies have been shown that owning a dog is good for you", 
-    **tokenization_kwargs
+encoded_input_ids = tokenizer(
+    "Studies have been shown that owning a dog is good for you", **tokenization_kwargs
 ).input_ids.cpu()
-decoder_input_ids = tokenizer("Studies show that", 
-    **tokenization_kwargs
+decoder_input_ids = tokenizer(
+    "Studies show that", **tokenization_kwargs
 ).input_ids.cpu()
 decoder_input_ids = model._shift_right(decoder_input_ids)
 attention_mask = torch.ones(1, 512).to("cpu")

--- a/e2eshark/pytorch/models/t5-large/model.py
+++ b/e2eshark/pytorch/models/t5-large/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
+++ b/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/vit-base-patch16-224/model.py
+++ b/e2eshark/pytorch/models/vit-base-patch16-224/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/whisper-base/model.py
+++ b/e2eshark/pytorch/models/whisper-base/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/whisper-medium/model.py
+++ b/e2eshark/pytorch/models/whisper-medium/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/models/whisper-small/model.py
+++ b/e2eshark/pytorch/models/whisper-small/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/operators/conv2d/model.py
+++ b/e2eshark/pytorch/operators/conv2d/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/operators/gridsampler/model.py
+++ b/e2eshark/pytorch/operators/gridsampler/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/operators/linear/model.py
+++ b/e2eshark/pytorch/operators/linear/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/pytorch/operators/silu/model.py
+++ b/e2eshark/pytorch/operators/silu/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/aztestsetup.py
+++ b/e2eshark/tools/aztestsetup.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/onnxutil.py
+++ b/e2eshark/tools/onnxutil.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/reportutil.py
+++ b/e2eshark/tools/reportutil.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/stubs/commonutils.py
+++ b/e2eshark/tools/stubs/commonutils.py
@@ -1,9 +1,10 @@
-import torch
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
 
 # These are pickle-saved and used by tools/stubs python and run.pl.
 # If adding new fields, make sure the field has default value and have updated

--- a/e2eshark/tools/stubs/onnxmodel.py
+++ b/e2eshark/tools/stubs/onnxmodel.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/stubs/pytorchmodel.py
+++ b/e2eshark/tools/stubs/pytorchmodel.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/e2eshark/tools/stubs/turbinemodel.py
+++ b/e2eshark/tools/stubs/turbinemodel.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/iree_tests/onnx/import_tests.py
+++ b/iree_tests/onnx/import_tests.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/iree_tests/pytorch/models/import_from_e2eshark.py
+++ b/iree_tests/pytorch/models/import_from_e2eshark.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Advanced Micro Devices
+# Copyright 2024 Advanced Micro Devices, Inc.
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
Sounds like this is the more standard form to include.