### PR TITLE
Model Tests with working model.py

### DIFF
--- a/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
@@ -21,29 +21,22 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 3, 256, 256).astype(numpy.float32)
+model_input_Y = numpy.random.rand(1, 3, 256, 256).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
 # gets Z in outputs[0]
 outputs = session.get_outputs()
 
-
 model_output = session.run(
     [outputs[0].name],
-    {inputs[0].name: model_input_X},
+    {inputs[0].name: model_input_X, inputs[1].name: model_input_Y},
 )[0]
-E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
-E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+E2ESHARK_CHECK["inputs"] = [torch.from_numpy(model_input_X), torch.from_numpy(model_input_Y)]
+E2ESHARK_CHECK["outputs"] = [torch.from_numpy(arr) for arr in model_output]
 
-print("Input:", E2ESHARK_CHECK["input"])
-print("Output:", E2ESHARK_CHECK["output"])
+print("Input:", E2ESHARK_CHECK["inputs"])
+print("Output:", E2ESHARK_CHECK["outputs"])
 
-# Post process output to do:
-# sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
-# Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# may need to add postprocess here #

--- a/e2eshark/onnx/models/RDN_pytorch_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RDN_pytorch_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 3, 256, 256).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()

--- a/e2eshark/onnx/models/pytorch-3dunet_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/pytorch-3dunet_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 1, 64, 128, 128).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()


### PR DESCRIPTION
RAFT_vaiq_int8
RDN_pytorch_vaiq_int8
pytorch-3dunet_vaiq_int8
(no change in MobileNetV3_small_vaiq_int8 needed)

Generated issues #598 #599

This commit is to provide correctly adapted model.py files to allow the test cases to run. 
model.onnx need to be downloaded still. 