### PR TITLE
Add e2e tests for ReduceProd with keeepdims attributes

### DIFF
--- a/e2eshark/onnx/operators/ReduceProdKeepdims0/model.py
+++ b/e2eshark/onnx/operators/ReduceProdKeepdims0/model.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Advanced Micro Devices
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# run.py creates runmodel.py by concatenating this file model.py
+# and tools/stubs/onnxmodel.py
+# Description: testing reduceprod
+# See https://onnx.ai/onnx/intro/python.html for intro on creating
+# onnx model using python onnx API
+import numpy, torch, sys
+import onnxruntime
+from onnx import numpy_helper, TensorProto, save_model
+from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_attribute
+from onnx.checker import check_model
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# Create an input (ValueInfoProto)
+X = make_tensor_value_info("X", TensorProto.FLOAT, [2, 3, 4])
+Y = make_tensor_value_info("Y", TensorProto.INT64, [1])
+
+# Create an output
+Z = make_tensor_value_info("Z", TensorProto.FLOAT, [2, 4])
+
+# Create a node (NodeProto)
+reduceprodnode = make_node(
+    "ReduceProd", ["X", "Y"], ["Z"], "reduceprodnode"  # node name  # inputs  # outputs
+)
+
+reduceprodnode.attribute.append(make_attribute("keepdims", 0))
+reduceprodnode.attribute.append(make_attribute("noop_with_empty_axes", 0))
+
+# Create the graph (GraphProto)
+graph = make_graph(
+    [reduceprodnode],
+    "reduceprodgraph",
+    [X, Y],
+    [Z],
+)
+
+# Create the model (ModelProto)
+onnx_model = make_model(graph)
+onnx_model.opset_import[0].version = 19
+
+# Save the model
+# save_model(onnx_model, "model.onnx")
+with open("model.onnx", "wb") as f:
+    f.write(onnx_model.SerializeToString())
+
+
+session = onnxruntime.InferenceSession("model.onnx", None)
+model_input_X = numpy.random.randn(2, 3, 4).astype(numpy.float32)
+model_input_Y = numpy.array([1]).astype(numpy.int64)
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X, inputs[1].name: model_input_Y},
+)
+
+# Moving to torch to handle bfloat16 as numpy does not support bfloat16
+E2ESHARK_CHECK["input"] = [
+    torch.from_numpy(model_input_X),
+    torch.from_numpy(model_input_Y),
+]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/operators/ReduceProdKeepdims1/model.py
+++ b/e2eshark/onnx/operators/ReduceProdKeepdims1/model.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Advanced Micro Devices
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# run.py creates runmodel.py by concatenating this file model.py
+# and tools/stubs/onnxmodel.py
+# Description: testing reduceprod
+# See https://onnx.ai/onnx/intro/python.html for intro on creating
+# onnx model using python onnx API
+import numpy, torch, sys
+import onnxruntime
+from onnx import numpy_helper, TensorProto, save_model
+from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_attribute
+from onnx.checker import check_model
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# Create an input (ValueInfoProto)
+X = make_tensor_value_info("X", TensorProto.FLOAT, [2, 3, 4])
+Y = make_tensor_value_info("Y", TensorProto.INT64, [1])
+
+# Create an output
+Z = make_tensor_value_info("Z", TensorProto.FLOAT, [2, 1, 4])
+
+# Create a node (NodeProto)
+reduceprodnode = make_node(
+    "ReduceProd", ["X", "Y"], ["Z"], "reduceprodnode"  # node name  # inputs  # outputs
+)
+
+reduceprodnode.attribute.append(make_attribute("keepdims", 1))
+reduceprodnode.attribute.append(make_attribute("noop_with_empty_axes", 0))
+
+# Create the graph (GraphProto)
+graph = make_graph(
+    [reduceprodnode],
+    "reduceprodgraph",
+    [X, Y],
+    [Z],
+)
+
+# Create the model (ModelProto)
+onnx_model = make_model(graph)
+onnx_model.opset_import[0].version = 19
+
+# Save the model
+# save_model(onnx_model, "model.onnx")
+with open("model.onnx", "wb") as f:
+    f.write(onnx_model.SerializeToString())
+
+
+session = onnxruntime.InferenceSession("model.onnx", None)
+model_input_X = numpy.random.randn(2, 3, 4).astype(numpy.float32)
+model_input_Y = numpy.array([1]).astype(numpy.int64)
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X, inputs[1].name: model_input_Y},
+)
+
+# Moving to torch to handle bfloat16 as numpy does not support bfloat16
+E2ESHARK_CHECK["input"] = [
+    torch.from_numpy(model_input_X),
+    torch.from_numpy(model_input_Y),
+]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])


### PR DESCRIPTION
Pass all tests with https://github.com/llvm/torch-mlir/pull/3134

```
| tests                              | model-run   | onnx-import   | torch-mlir   | iree-compile   | inference   |
|:-----------------------------------|:------------|:--------------|:-------------|:---------------|:------------|
| onnx/operators/ReduceProdKeepdims1 | passed      | passed        | passed       | passed         | passed      |
|:-----------------------------------|:------------|:--------------|:-------------|:---------------|:------------|
| onnx/operators/ReduceProdKeepdims0 | passed      | passed        | passed       | passed         | passed      |
```