### PR TITLE
Enable Onnx Model Tests

### DIFF
--- a/e2eshark/onnx/.gitignore
+++ b/e2eshark/onnx/.gitignore
@@ -1,2 +1,4 @@
 # Model artifacts
 operators/*/model.onnx
+models/*/model.onnx
+models/*/model.onnxsignature.json

--- a/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/ConvNeXt_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/ConvNeXt_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/DarkNet53_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/DarkNet53_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/DenseNet201_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/DenseNet201_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/EfficientNet_v2_s_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/FCN_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/FCN_vaiq_int8/model.py
@@ -30,7 +30,7 @@ outputs = session.get_outputs()
 
 
 model_output = session.run(
-    [outputs[0].name],
+    [outputs[0].name, outputs[1].name],
     {inputs[0].name: model_input_X},
 )[0]
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]

--- a/e2eshark/onnx/models/GoogLeNet_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/GoogLeNet_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/Inception_v4_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/Inception_v4_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(32, 3, 224, 224).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/KeypointRCNN_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/KeypointRCNN_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/LRASPP_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/LRASPP_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/MNASNet_1_3_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/MNASNet_1_3_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/MobileNetV3_small_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_small_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
@@ -31,7 +31,8 @@ outputs = session.get_outputs()
 
 model_output = session.run(
     [outputs[0].name],
-    {inputs[0].name: model_input_X, inputs[1].name: model_input_Y},
+    {inputs[0].name: model_input_X,
+     inputs[1].name: model_input_Y},
 )[0]
 E2ESHARK_CHECK["inputs"] = [torch.from_numpy(model_input_X), torch.from_numpy(model_input_Y)]
 E2ESHARK_CHECK["outputs"] = [torch.from_numpy(arr) for arr in model_output]
@@ -39,4 +40,11 @@ E2ESHARK_CHECK["outputs"] = [torch.from_numpy(arr) for arr in model_output]
 print("Input:", E2ESHARK_CHECK["inputs"])
 print("Output:", E2ESHARK_CHECK["outputs"])
 
-# may need to add postprocess here #
+# Post process output to do:
+# sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
+# Top most probability
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/RDN_pytorch_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RDN_pytorch_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/RRDB_ESRGAN_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/RegNet_y_8gf_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RegNet_y_8gf_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/ResNet152_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/ResNet152_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/ShuffleNet_v2_x2_0_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/ShuffleNet_v2_x2_0_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/SqueezeNet_1_1_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_1_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/VGG11_bn_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/VGG11_bn_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/VGG19_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/VGG19_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/VideoResNet_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/VideoResNet_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 3, 112, 224, 224).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/WideResNet_50_2_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/WideResNet_50_2_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/YoloNetV3_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/YoloNetV3_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(4, 3, 416, 416).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/pytorch-3dunet_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/pytorch-3dunet_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 1, 64, 128, 128).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 1, 64, 224, 224).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/resnet50_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/resnet50_vaiq_int8/model.py
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/retinanet_resnet50_fpn_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/retinanet_resnet50_fpn_vaiq_int8/model.py
@@ -30,7 +30,7 @@ outputs = session.get_outputs()
 
 
 model_output = session.run(
-    [outputs[0].name],
+    [outputs[0].name, outputs[1].name, outputs[2].name],
     {inputs[0].name: model_input_X},
 )[0]
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/u-net_brain_mri_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/u-net_brain_mri_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(32, 3, 256, 256).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/onnx/models/yolov8n_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/yolov8n_vaiq_int8/model.py
@@ -21,7 +21,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
-model_input_X = numpy.random.rand(1, 3, 224, 224).astype(numpy.float32)
+model_input_X = numpy.random.rand(1, 3, 640, 640).astype(numpy.float32)
 
 # gets X in inputs[0] and Y in inputs[1]
 inputs = session.get_inputs()
@@ -30,7 +30,7 @@ outputs = session.get_outputs()
 
 
 model_output = session.run(
-    [outputs[0].name],
+    [outputs[0].name, outputs[1].name, outputs[2].name, outputs[3].name],
     {inputs[0].name: model_input_X},
 )[0]
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
@@ -42,8 +42,8 @@ print("Output:", E2ESHARK_CHECK["output"])
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]
 # Top most probability
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [2], True, 1),
-    (torch.sort, [], True, 0),
-]
+# E2ESHARK_CHECK["postprocess"] = [
+#     (torch.nn.functional.softmax, [0], False, 0),
+#     (torch.topk, [2], True, 1),
+#     (torch.sort, [], True, 0),
+# ]

--- a/e2eshark/tools/onnxutil.py
+++ b/e2eshark/tools/onnxutil.py
@@ -42,6 +42,9 @@ if __name__ == "__main__":
         "-p", "--print", action="store_true", help="Print in human readable format"
     )
     parser.add_argument(
+        "-s", "--signature", action="store_true", help="Get model input output information"
+    )
+    parser.add_argument(
         "-f",
         "--frequency",
         action="store_true",
@@ -77,3 +80,11 @@ if __name__ == "__main__":
                 print(k, ":", v)
                 count += v
             print("Total instances of ops: ", count)
+        if args.signature:
+            # Get the input and output nodes of the model
+            ofilename = os.path.basename(onnxfile) + "signature.json"
+            with open(ofilename, "w") as ofile:
+                print("INPUTS: \n", file=ofile)
+                print(model.graph.input, file=ofile)
+                print("------------------------\nOUTPUTS: \n", file=ofile)
+                print(model.graph.output, file=ofile)


### PR DESCRIPTION
- adds support for downloading and running the e2e tests for onnx models

- currently supported models: 
    - onnx/models/DarkNet53_vaiq_int8 
    - onnx/models/DenseNet201_vaiq_int8 
    - onnx/models/EfficientNet_v2_s_vaiq_int8 
    - onnx/models/GoogLeNet_vaiq_int8 
    - onnx/models/Inception_v4_vaiq_int8 
    - onnx/models/LRASPP_vaiq_int8 
    - onnx/models/MNASNet_1_3_vaiq_int8 
    - onnx/models/MobileNetV3_small_vaiq_int8 
    - onnx/models/RDN_pytorch_vaiq_int8 
    - onnx/models/RegNet_y_8gf_vaiq_int8 
    - onnx/models/ResNet152_vaiq_int8 
    - onnx/models/retinanet_resnet50_fpn_vaiq_int8 
    - onnx/models/RRDB_ESRGAN_vaiq_int8 
    - onnx/models/ShuffleNet_v2_x2_0_vaiq_int8 
    - onnx/models/SqueezeNet_1_1_vaiq_int8 
    - onnx/models/VGG11_bn_vaiq_int8 
    - onnx/models/VGG19_vaiq_int8 
    - onnx/models/VideoResNet_vaiq_int8 
    - onnx/models/WideResNet_50_2_vaiq_int8 
    - onnx/models/YoloNetV3_vaiq_int8 
    - onnx/models/yolov8n_vaiq_int8 
    - onnx/models/u-net_brain_mri_vaiq_int8 
   
   More on the way :)