### PR TITLE
Adds an e2e test for DQL -> MatMulInteger seen in Opt

### DIFF
--- a/e2eshark/onnx/combinations/QuantizeToMatMulInteger/model.py
+++ b/e2eshark/onnx/combinations/QuantizeToMatMulInteger/model.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# run.py creates runmodel.py by concatenating this file model.py
+# and tools/stubs/onnxmodel.py
+
+# See https://onnx.ai/onnx/intro/python.html for intro on creating
+# onnx model using python onnx API
+import numpy, torch, sys
+import onnxruntime
+from onnx import numpy_helper, TensorProto, save_model
+from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info
+from onnx.checker import check_model
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+# Create an input (ValueInfoProto)
+X = make_tensor_value_info("X", TensorProto.FLOAT, [2, 4, 5])
+Y = make_tensor_value_info("Y", TensorProto.FLOAT, [5, 3])
+
+# Create an output
+Z = make_tensor_value_info("Z", TensorProto.INT32, [2, 4, 3])
+
+# Create a node (NodeProto)
+qlxnode = make_node(
+    "DynamicQuantizeLinear", ["X"], ["QX", "SX", "ZPX"], "qlxnode"
+)
+qlynode = make_node(
+    "DynamicQuantizeLinear", ["Y"], ["QY", "SY", "ZPY"], "qlynode"
+)
+mminode = make_node(
+    "MatMulInteger", ["QX", "QY", "ZPX", "ZPY"], ["Z"], "mminode"  # node name  # inputs  # outputs
+)
+
+# Create the graph (GraphProto)
+graph = make_graph(
+    [qlxnode,qlynode, mminode],
+    "mmigraph",
+    [X, Y],
+    [Z],
+)
+
+# Create the model (ModelProto)
+onnx_model = make_model(graph)
+onnx_model.opset_import[0].version = 19
+
+# Save the model
+# save_model(onnx_model, "model.onnx")
+with open("model.onnx", "wb") as f:
+    f.write(onnx_model.SerializeToString())
+
+session = onnxruntime.InferenceSession("model.onnx", None)
+model_input_X = numpy.random.randn(2, 4, 5).astype(numpy.float32)
+model_input_Y = numpy.random.randn(5, 3).astype(numpy.float32)
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X, inputs[1].name: model_input_Y},
+)
+
+# Moving to torch to handle bfloat16 as numpy does not support bfloat16
+E2ESHARK_CHECK["input"] = [
+    torch.from_numpy(model_input_X),
+    torch.from_numpy(model_input_Y),
+]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -221,6 +221,8 @@ def unpackBytearray(barray, num_elem, dtype):
         temptensor = torch.tensor(num_array, dtype=torch.int16)
         rettensor = temptensor.view(dtype=torch.float16)
         return rettensor
+    elif dtype == torch.int32:
+        num_array = struct.unpack("l" * num_elem, barray)
     elif dtype == torch.int16:
         num_array = struct.unpack("h" * num_elem, barray)
     elif dtype == torch.int8:


### PR DESCRIPTION
This is to test some work I'm doing on quantized batch matmul in torch-mlir to get Opt-125m to lower to linalg. 

For now, I'm focusing on the one case I'm seeing in opt-125m which is rank3 x rank2 -> rank3 MatMulInteger ops. 