### PR TITLE
Add caching support for model testing

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: nodai-amdgpu-w7900-x86-64
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
+      IREE_TEST_FILES: ~/iree_tests_cache
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4

--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -12,8 +12,10 @@ import logging
 import mmap
 import pyjson5
 import re
+import os
 
 THIS_DIR = Path(__file__).parent
+REPO_ROOT = Path(__file__).parent.parent
 logger = logging.getLogger(__name__)
 
 
@@ -81,7 +83,18 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
         blob_size_str = human_readable_size(blob_properties.size)
         remote_md5 = get_remote_md5(remote_file, blob_properties)
 
-        local_file_path = test_dir / remote_file_name
+        cache_location = os.getenv("IREE_TEST_FILES", default="")
+        if cache_location == "":
+            os.environ["IREE_TEST_FILES"] = str(REPO_ROOT)
+            cache_location = REPO_ROOT
+        if cache_location == REPO_ROOT:
+            local_dir_path = test_dir
+            local_file_path = test_dir / remote_file_name
+        else:
+            cache_location = os.path.expanduser(cache_location)
+            local_dir_path = Path(cache_location) / "iree_tests" / relative_dir
+            local_file_path = Path(cache_location) / "iree_tests" / relative_dir / remote_file_name
+
         local_md5 = get_local_md5(local_file_path)
 
         if remote_md5 and remote_md5 == local_md5:
@@ -89,6 +102,7 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
                 f"  Skipping '{remote_file_name}' download ({blob_size_str}) "
                 "- local MD5 hash matches"
             )
+            os.symlink(local_file_path, test_dir / remote_file_name)
             return
 
         if not local_md5:
@@ -102,9 +116,13 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
                 f"to '{relative_dir}' (local MD5 does not match)"
             )
 
+        if not os.path.isdir(local_dir_path):
+            os.makedirs(local_dir_path)
         with open(local_file_path, mode="wb") as local_blob:
             download_stream = blob_client.download_blob(max_concurrency=4)
             local_blob.write(download_stream.readall())
+        if str(cache_location) != str(REPO_ROOT):
+            os.symlink(local_file_path, test_dir / remote_file_name)
 
 
 def download_generic_remote_file(test_dir: Path, remote_file: str):

--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -91,9 +91,9 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
             local_dir_path = test_dir
             local_file_path = test_dir / remote_file_name
         else:
-            cache_location = os.path.expanduser(cache_location)
-            local_dir_path = Path(cache_location) / "iree_tests" / relative_dir
-            local_file_path = Path(cache_location) / "iree_tests" / relative_dir / remote_file_name
+            cache_location = Path(cache_location).resolve()
+            local_dir_path = cache_location / "iree_tests" / relative_dir
+            local_file_path = cache_location / "iree_tests" / relative_dir / remote_file_name
 
         local_md5 = get_local_md5(local_file_path)
 
@@ -103,6 +103,9 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
                 "- local MD5 hash matches"
             )
             os.symlink(local_file_path, test_dir / remote_file_name)
+            logger.info(
+                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}' "
+            )
             return
 
         if not local_md5:
@@ -123,6 +126,9 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
             local_blob.write(download_stream.readall())
         if str(cache_location) != str(REPO_ROOT):
             os.symlink(local_file_path, test_dir / remote_file_name)
+            logger.info(
+                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}' "
+            )
 
 
 def download_generic_remote_file(test_dir: Path, remote_file: str):

--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -104,7 +104,7 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
             )
             os.symlink(local_file_path, test_dir / remote_file_name)
             logger.info(
-                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}' "
+                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}'"
             )
             return
 
@@ -127,7 +127,7 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
         if str(cache_location) != str(REPO_ROOT):
             os.symlink(local_file_path, test_dir / remote_file_name)
             logger.info(
-                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}' "
+                f"  Created symlink for '{local_file_path}' to '{test_dir / remote_file_name}'"
             )
 
 

--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -91,7 +91,7 @@ def download_azure_remote_file(test_dir: Path, remote_file: str):
             local_dir_path = test_dir
             local_file_path = test_dir / remote_file_name
         else:
-            cache_location = Path(cache_location).resolve()
+            cache_location = Path(os.path.expanduser(cache_location)).resolve()
             local_dir_path = cache_location / "iree_tests" / relative_dir
             local_file_path = cache_location / "iree_tests" / relative_dir / remote_file_name
 


### PR DESCRIPTION
This commit adds caching support for model testing. This brings the download time from ~20 mins to 23 seconds. With these changes, it is feasible to add model testing as a presubmit in the iree repo which was the reason for these changes. 

Description of what's going on:  
First, we use an environment variable passed in (IREE_TEST_FILES) to determine if we even want to use a cache or not (don't want to make it a requirement). In CI, we set this because we want a persistent runner cache. If this is set, we download files to the cache location specified and symlink it to the testing directory. Otherwise, we just directly download into the repo, and it won't be using any caching mechanism. The test runner doesn't need to know about caching at all, and even initially, it will just create the cache and download there if it doesn't exist. There is no manual interaction that needs to take place for any system or person that wants to use this.

Example of actions run first time and second time (runner knows nothing about caching, no manual setup):
https://github.com/nod-ai/SHARK-TestSuite/actions/runs/8711532825
https://github.com/nod-ai/SHARK-TestSuite/actions/runs/8711798501

Final model testing job time: ~5 mins

The machine in the iree repo is even faster, so can expect lower times :)

Fixes https://github.com/nod-ai/SHARK-TestSuite/issues/169