### PR TITLE
Add option to fail pytest collection if files are missing.

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -96,7 +96,6 @@ jobs:
         run: |
           source ${VENV_DIR}/bin/activate
           python3 -m pip install -r iree_tests/requirements.txt
-      # TODO(scotttodd): add a local cache for these large files to a persistent runner
       - name: "Downloading remote files for real weight model tests"
         run: |
           source ${VENV_DIR}/bin/activate
@@ -106,4 +105,13 @@ jobs:
             IREE_TEST_CONFIG_FILES: iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
         run: |
           source ${VENV_DIR}/bin/activate
-          pytest iree_tests/pytorch/models -s -n 4 -k real_weights -rpfE --timeout=1200 --retries 2 --retry-delay 5 --durations=0
+          pytest iree_tests/pytorch/models \
+            -n 4 \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --timeout=1200 \
+            --retries 2 \
+            --retry-delay 5 \
+            --durations=0 \

--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -7,6 +7,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
+import argparse
 import pyjson5
 import os
 import pytest
@@ -77,6 +78,13 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
         help="Skips all 'run' tests, overriding 'skip_run_tests' in configs",
+    )
+
+    parser.addoption(
+        "--skip-tests-missing-files",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Skips any tests that are missing required files",
     )
 
 
@@ -194,13 +202,13 @@ class MlirFile(pytest.File):
                     f"Missing file '{remote_file}' for test {self.path.parent.name}::{test_case_name}"
                 )
                 have_all_files = False
-                break
         return have_all_files
 
     def discover_test_cases(self):
         """Discovers test cases in either test_data_flags.txt or *.json files."""
         test_cases = []
 
+        skip_missing = self.config.getoption("skip_tests_missing_files")
         have_lfs_files = self.check_for_lfs_files()
 
         test_data_flagfile_name = "test_data_flags.txt"
@@ -220,12 +228,18 @@ class MlirFile(pytest.File):
                     continue
                 for test_case_json in test_cases_json["test_cases"]:
                     test_case_name = test_case_json["name"]
-                    have_all_files = self.check_for_remote_files(test_case_json)
+                    have_remote_files = self.check_for_remote_files(test_case_json)
+                    have_all_files = have_lfs_files and have_remote_files
+
+                    if not skip_missing and not have_all_files:
+                        raise FileNotFoundError(
+                            f"Missing files for test {self.path.parent.name}::{test_case_name}"
+                        )
                     test_cases.append(
                         MlirFile.TestCase(
                             name=test_case_name,
                             runtime_flagfile=test_case_json["runtime_flagfile"],
-                            enabled=have_lfs_files and have_all_files,
+                            enabled=have_all_files,
                         )
                     )
 

--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -305,6 +305,12 @@ class IreeCompileRunItem(pytest.Item):
         super().__init__(**kwargs)
         self.spec = spec
 
+        if self.spec.skip_test:
+            self.add_marker(
+                pytest.mark.skip(f"{self.spec.test_name} missing required files")
+            )
+            return
+
         # TODO(scotttodd): swap cwd for a temp path?
         self.test_cwd = self.spec.test_directory
         vmfb_name = f"{self.spec.input_mlir_stem}_{self.spec.test_name}.vmfb"
@@ -318,9 +324,6 @@ class IreeCompileRunItem(pytest.Item):
         self.run_args.append(f"--flagfile={self.spec.data_flagfile_name}")
 
     def runtest(self):
-        if self.spec.skip_test:
-            pytest.skip()
-
         # We want to test two phases: 'compile', and 'run'.
         # A test can be marked as expected to fail at either stage, with these
         # possible outcomes:


### PR DESCRIPTION
I wanted developers to be able to run the full test suite without needing to download all files. That meant skipping tests if files were not downloaded. On CI machines, we probably want to fail instead of skipping tests, as we _should_ be downloading all files or pulling them from a cache. This adds a flag that lets us control that behavior.