### PR TITLE
Drop unnecessary cpu flag

### DIFF
--- a/iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
+++ b/iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
@@ -2,8 +2,7 @@
     "config_name": "cpu_llvm_task",
     "iree_compile_flags" : [
       "--iree-hal-target-backends=llvm-cpu",
-      "--iree-llvmcpu-target-cpu-features=host",
-      "--iree-llvmcpu-distribution-size=32"
+      "--iree-llvmcpu-target-cpu-features=host"
     ],
     "iree_run_module_flags": [
       "--device=local-task"

--- a/iree_tests/configs/config_sdxl_scheduled_unet_cpu_llvm_task.json
+++ b/iree_tests/configs/config_sdxl_scheduled_unet_cpu_llvm_task.json
@@ -2,8 +2,7 @@
     "config_name": "cpu_llvm_task",
     "iree_compile_flags" : [
       "--iree-hal-target-backends=llvm-cpu",
-      "--iree-llvmcpu-target-cpu-features=host",
-      "--iree-llvmcpu-distribution-size=32"
+      "--iree-llvmcpu-target-cpu-features=host"
     ],
     "iree_run_module_flags": [
       "--device=local-task",


### PR DESCRIPTION
Drops the --iree-llvmcpu-distribution-size=32 flag that is no longer required. Have a PR in iree for this too