### PR TITLE
Update requirements and get CI working for e2eshark

### DIFF
--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -41,6 +41,8 @@ jobs:
           source ${E2E_VENV_DIR}/bin/activate
           pip install --upgrade pip
           pip install -r ./e2eshark/requirements.txt
+          pip uninstall -y numpy
+          pip install numpy
         working-directory: ./test-suite
 
       - name: Run Onnx Mode

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -40,6 +40,8 @@ jobs:
           python3.11 -m venv ${E2E_VENV_DIR}
           source ${E2E_VENV_DIR}/bin/activate
           pip install --upgrade pip
+          pip install -r https://raw.githubusercontent.com/llvm/torch-mlir/main/requirements.txt
+          pip install -r https://raw.githubusercontent.com/llvm/torch-mlir/main/torchvision-requirements.txt
           pip install -r ./e2eshark/requirements.txt
         working-directory: ./test-suite
 

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -40,8 +40,6 @@ jobs:
           python3.11 -m venv ${E2E_VENV_DIR}
           source ${E2E_VENV_DIR}/bin/activate
           pip install --upgrade pip
-          pip install -r https://raw.githubusercontent.com/llvm/torch-mlir/main/requirements.txt
-          pip install -r https://raw.githubusercontent.com/llvm/torch-mlir/main/torchvision-requirements.txt
           pip install -r ./e2eshark/requirements.txt
         working-directory: ./test-suite
 

--- a/e2eshark/ci-requirements.txt
+++ b/e2eshark/ci-requirements.txt
@@ -6,4 +6,3 @@ accelerate
 auto-gptq
 optimum
 azure-storage-blob
-pillow

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -5,9 +5,7 @@ onnx
 onnxruntime
 transformers
 huggingface-cli
-pillow
 sentencepiece
-torchvision
 accelerate
 auto-gptq
 optimum

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -7,6 +7,7 @@ transformers
 huggingface-cli
 pillow
 sentencepiece
+torchvision
 accelerate
 auto-gptq
 optimum

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -16,3 +16,5 @@ torch-mlir
 # install nightly build of iree-compiler and iree-runtime
 iree-compiler -f https://iree.dev/pip-release-links.html
 iree-runtime -f https://iree.dev/pip-release-links.html
+-r https://raw.githubusercontent.com/llvm/torch-mlir/main/requirements.txt
+-r https://raw.githubusercontent.com/llvm/torch-mlir/main/torchvision-requirements.txt

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -1,3 +1,5 @@
+-r https://raw.githubusercontent.com/llvm/torch-mlir/main/requirements.txt
+-r https://raw.githubusercontent.com/llvm/torch-mlir/main/torchvision-requirements.txt
 tabulate
 simplejson
 ml_dtypes
@@ -16,5 +18,3 @@ torch-mlir
 # install nightly build of iree-compiler and iree-runtime
 iree-compiler -f https://iree.dev/pip-release-links.html
 iree-runtime -f https://iree.dev/pip-release-links.html
--r https://raw.githubusercontent.com/llvm/torch-mlir/main/requirements.txt
--r https://raw.githubusercontent.com/llvm/torch-mlir/main/torchvision-requirements.txt

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -5,6 +5,7 @@ onnx
 onnxruntime
 transformers
 huggingface-cli
+pillow
 sentencepiece
 accelerate
 auto-gptq


### PR DESCRIPTION
will pin numpy if everyone experiences the pip installing the pre release version