### PR TITLE
Treat .bin files as binary in git.

### DIFF
--- a/iree_tests/.gitattributes
+++ b/iree_tests/.gitattributes
@@ -1,3 +1,6 @@
 *.irpa filter=lfs diff=lfs merge=lfs -text
 *.mlirbc filter=lfs diff=lfs merge=lfs -text
-*.bin binary
+
+# Ignore diffs and treat as binary in Git and on GitHub.
+*.bin -diff
+*.bin binary linguist-generated

--- a/iree_tests/.gitattributes
+++ b/iree_tests/.gitattributes
@@ -1,2 +1,3 @@
 *.irpa filter=lfs diff=lfs merge=lfs -text
 *.mlirbc filter=lfs diff=lfs merge=lfs -text
+*.bin binary


### PR DESCRIPTION
I think this will help if the file contents change, preventing git from trying to merge files as text. I _hoped_ this would also show the files as binary, but that isn't working:
* Correctly binary: https://github.com/nod-ai/SHARK-TestSuite/blob/main/iree_tests/onnx/node/generated/test_abs/output_0.npy
* Incorrectly text: https://github.com/nod-ai/SHARK-TestSuite/blob/main/iree_tests/onnx/node/generated/test_abs/output_0.bin

We're already saving those files as binary, so something in the file extensions might be special cased ¯\\\_(ツ)\_/¯