### PR TITLE
Support logging compile and run commands even if successful.

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -125,7 +125,7 @@ jobs:
           source ${VENV_DIR}/bin/activate
           python3 iree_tests/download_remote_files.py --root-dir pytorch/models
 
-      - name: "Running real weight model tests cpu"
+      - name: "Running real weight model tests - CPU"
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree_tests/pytorch/models \
@@ -134,13 +134,14 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \
             --durations=0 \
             --config-files=iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
 
-      - name: "Running real weight model tests scheduled unet cpu"
+      - name: "Running real weight model tests - Scheduled UNet CPU"
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank \
@@ -148,6 +149,7 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \
@@ -190,7 +192,7 @@ jobs:
           source ${VENV_DIR}/bin/activate
           python3.11 iree_tests/download_remote_files.py --root-dir pytorch/models
 
-      - name: "Running real weight model tests ROCm AMDGPU"
+      - name: "Running real weight model tests - ROCm AMDGPU"
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree_tests/pytorch/models \
@@ -198,13 +200,14 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \
             --durations=0 \
             --config-files=iree_tests/configs/config_gpu_rocm_models.json
 
-      - name: "Running real weight model tests scheduled unet ROCm AMDGPU"
+      - name: "Running real weight model tests - Scheduled UNet ROCm AMDGPU"
         run: |
           source ${VENV_DIR}/bin/activate
           pytest iree_tests/pytorch/models/sdxl-scheduled-unet-3-tank \
@@ -212,6 +215,7 @@ jobs:
             -k real_weights \
             --no-skip-tests-missing-files \
             --capture=no \
+            --log-cli-level=info \
             --timeout=1200 \
             --retries 2 \
             --retry-delay 5 \

--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -322,6 +322,10 @@ class IreeCompileRunItem(pytest.Item):
         self.run_args.append(f"--flagfile={self.spec.data_flagfile_name}")
 
     def runtest(self):
+        # TODO(scotttodd): log files needed by the test (remote files / git LFS)
+        #     it should be easy to copy/paste commands from CI logs to get both
+        #     the test files and the flags used with them
+
         # We want to test two phases: 'compile', and 'run'.
         # A test can be marked as expected to fail at either stage, with these
         # possible outcomes:

--- a/iree_tests/conftest.py
+++ b/iree_tests/conftest.py
@@ -378,7 +378,9 @@ class IreeCompileRunItem(pytest.Item):
 
     def test_compile(self):
         compile_env = os.environ.copy()
-        compile_env["IREE_TEST_PATH_EXTENSION"] = os.getenv("IREE_TEST_PATH_EXTENSION", default=self.test_cwd)
+        compile_env["IREE_TEST_PATH_EXTENSION"] = os.getenv(
+            "IREE_TEST_PATH_EXTENSION", default=str(self.test_cwd)
+        )
         path_extension = compile_env["IREE_TEST_PATH_EXTENSION"]
         cmd = subprocess.list2cmdline(self.compile_args)
         cmd = cmd.replace("${IREE_TEST_PATH_EXTENSION}", f"{path_extension}")


### PR DESCRIPTION
Fixes https://github.com/nod-ai/SHARK-TestSuite/issues/223

More can be added later. For now, this makes setting `--log-cli-level=info` include some extra info for each test case regardless of whether the test passed or failed:

```
iree_tests/pytorch/models/sdxl-vae-decode-tank/model.mlirbc::gpu_rocm_real_weights 
-------------------------------- live log call ---------------------------------
INFO     root:conftest.py:393 Launching compile command:
cd /mnt/share/amdsharks/actions-runner/_work/SHARK-TestSuite/SHARK-TestSuite/iree_tests/pytorch/models/sdxl-vae-decode-tank && iree-compile model.mlirbc --iree-hal-target-backends=rocm --iree-rocm-target-chip=gfx90a --iree-opt-const-eval=false --iree-codegen-transform-dialect-library=/mnt/share/amdsharks/actions-runner/_work/SHARK-TestSuite/SHARK-TestSuite/iree_tests/specs/attention_and_matmul_spec.mlir -o model_gpu_rocm_real_weights.vmfb
INFO     root:conftest.py:407 Launching run command:
cd /mnt/share/amdsharks/actions-runner/_work/SHARK-TestSuite/SHARK-TestSuite/iree_tests/pytorch/models/sdxl-vae-decode-tank && iree-run-module --module=model_gpu_rocm_real_weights.vmfb --device=hip --flagfile=real_weights_data_flags.txt
PASSED
```