### PR TITLE
Fix the torchtolinalg == False passpipeline

### DIFF
--- a/e2eshark/run.py
+++ b/e2eshark/run.py
@@ -158,8 +158,10 @@ def runOnnxToTorchMLIRGeneration(
             )
             commandstring += "torch-backend-to-linalg-on-tensors-backend-pipeline)' "
         else:
-            commandstring += " -convert-torch-onnx-to-torch "
-
+            commandstring += " -pass-pipeline='builtin.module(func.func(convert-torch-onnx-to-torch),"
+            commandstring += (
+                "torch-lower-to-backend-contract,func.func(cse,canonicalize))' "
+            )
         # TORCH_MLIR_BUILD = path_config["TORCH_MLIR_BUILD"]
         # print(f"In RunTest - torch mlir build - {SHARED_TORCH_MLIR_BUILD}")
         scriptcommand = (


### PR DESCRIPTION
 There tests all based on the torch-mlir&iree llvm b3291793f119 Apr 30 and iree a075013cf May 7th.

`python ./run.py --torchmlirbuild ../../torch-mlir/build --tolerance 0.001 0.001 --cachedir ./huggingface_cache --ireebuild ../../iree-build  -f pytorch -g models --mode onnx --report`
Status report for run: test-run using mode:onnx todtype:default backend:llvm-cpu

| tests                                            | model-run   | onnx-import   | torch-mlir   | iree-compile   | inference   |
|:-------------------------------------------------|:------------|:--------------|:-------------|:---------------|:------------|
| pytorch/models/gpt2                              | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/opt-125M                          | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/bart-large                        | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/whisper-base                      | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/beit-base-patch16-224-pt22k-ft22k | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/deit-small-distilled-patch16-224  | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/resnet50                          | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/llama2-7b-GPTQ                    | failed      | notrun        | notrun       | notrun         | notrun      |
| pytorch/models/mobilebert-uncased                | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/vicuna-13b-v1.3                   | failed      | notrun        | notrun       | notrun         | notrun      |
| pytorch/models/phi-1_5                           | passed      | passed        | passed       | passed         | mismatch    |
| pytorch/models/opt-350m                          | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/vit-base-patch16-224              | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/phi-2                             | passed      | passed        | passed       | passed         | mismatch    |
| pytorch/models/dlrm                              | passed      | passed        | failed       | notrun         | notrun      |
| pytorch/models/gpt2-xl                           | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/opt-125m-gptq                     | failed      | notrun        | notrun       | notrun         | notrun      |
| pytorch/models/whisper-medium                    | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/stablelm-3b-4e1t                  | passed      | failed        | notrun       | notrun         | notrun      |
| pytorch/models/opt-1.3b                          | passed      | passed        | passed       | failed         | notrun      |
| pytorch/models/whisper-small                     | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/t5-large                          | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/gemma-7b                          | failed      | notrun        | notrun       | notrun         | notrun      |
| pytorch/models/miniLM-L12-H384-uncased           | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/mit-b0                            | passed      | passed        | passed       | passed         | mismatch    |
| pytorch/models/bert-large-uncased                | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/t5-base                           | passed      | passed        | passed       | passed         | passed      |
| pytorch/models/llama2-7b-hf                      | failed      | notrun        | notrun       | notrun         | notrun      |
| pytorch/models/bge-base-en-v1.5                  | passed      | passed        | passed       | passed         | passed      |

`python ./run.py --torchmlirbuild ../../torch-mlir/build --tolerance 0.001 0.001 --cachedir ./huggingface_cache --ireebuild ../../iree-build  -f onnx -g models --mode onnx --report`

```
Status report for run: test-run using mode:onnx todtype:default backend:llvm-cpu

| tests                                        | model-run   | onnx-import   | torch-mlir   | iree-compile   | inference   |
|:---------------------------------------------|:------------|:--------------|:-------------|:---------------|:------------|
| onnx/models/DenseNet201_vaiq_int8            | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/U-2-Net_vaiq_int8                | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/RegNet_y_8gf_vaiq_int8           | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/DarkNet53_vaiq_int8              | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/pytorch-3dunet_vaiq_int8         | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/RAFT_vaiq_int8                   | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/YoloNetV3_vaiq_int8              | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/yolov8n_vaiq_int8                | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/VideoResNet_vaiq_int8            | passed      | passed        | passed       | failed         | notrun      |
| onnx/models/WideResNet_50_2_vaiq_int8        | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/u-net_brain_mri_vaiq_int8        | passed      | passed        | passed       | passed         | failed      |
| onnx/models/GoogLeNet_vaiq_int8              | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/ShuffleNet_v2_x2_0_vaiq_int8     | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/retinanet_resnet50_fpn_vaiq_int8 | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/DeepLabV3_resnet50_vaiq_int8     | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/RRDB_ESRGAN_vaiq_int8            | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/FCN_vaiq_int8                    | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/llama2-7b-awq                    | failed      | notrun        | notrun       | notrun         | notrun      |
| onnx/models/LRASPP_vaiq_int8                 | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/QuantizedMLP                     | passed      | passed        | passed       | passed         | passed      |
| onnx/models/RDN_pytorch_vaiq_int8            | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/resnet50_vaiq_int8               | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/EfficientNet_v2_s_vaiq_int8      | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/MNASNet_1_3_vaiq_int8            | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/opt-125M-awq                     | passed      | passed        | passed       | failed         | notrun      |
| onnx/models/AlexNet_vaiq_int8                | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/VGG11_bn_vaiq_int8               | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/ResNet152_vaiq_int8              | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/KeypointRCNN_vaiq_int8           | passed      | passed        | failed       | notrun         | notrun      |
| onnx/models/CSP-DarkNet_vaiq_int8            | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/SqueezeNet_1_1_vaiq_int8         | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/MobileNetV3_small_vaiq_int8      | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/Inception_v4_vaiq_int8           | passed      | passed        | passed       | failed         | notrun      |
| onnx/models/ConvNeXt_vaiq_int8               | passed      | passed        | passed       | passed         | mismatch    |
| onnx/models/VGG19_vaiq_int8                  | passed      | passed        | passed       | passed         | mismatch    |

```