### PR TITLE
Remove unused imports from e2eshark/pytorch/**/model.py files.

### DIFF
--- a/e2eshark/pytorch/models/bart-large/model.py
+++ b/e2eshark/pytorch/models/bart-large/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import BartForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/beit-base-patch16-224-pt22k-ft22k/model.py
+++ b/e2eshark/pytorch/models/beit-base-patch16-224-pt22k-ft22k/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import BeitImageProcessor, BeitForImageClassification
 from PIL import Image
 import requests

--- a/e2eshark/pytorch/models/bert-large-uncased/model.py
+++ b/e2eshark/pytorch/models/bert-large-uncased/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import BertLMHeadModel, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
+++ b/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import BertLMHeadModel, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/deit-small-distilled-patch16-224/model.py
+++ b/e2eshark/pytorch/models/deit-small-distilled-patch16-224/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import DeiTImageProcessor, DeiTForImageClassification
 from PIL import Image
 import requests

--- a/e2eshark/pytorch/models/gpt2-xl/model.py
+++ b/e2eshark/pytorch/models/gpt2-xl/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/gpt2/model.py
+++ b/e2eshark/pytorch/models/gpt2/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
+++ b/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import BertLMHeadModel, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/mit-b0/model.py
+++ b/e2eshark/pytorch/models/mit-b0/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import SegformerImageProcessor, SegformerForImageClassification
 from PIL import Image
 import requests

--- a/e2eshark/pytorch/models/mobilebert-uncased/model.py
+++ b/e2eshark/pytorch/models/mobilebert-uncased/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import MobileBertForSequenceClassification, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/opt-1.3b/model.py
+++ b/e2eshark/pytorch/models/opt-1.3b/model.py
@@ -1,7 +1,11 @@
-import sys, argparse
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import OPTForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/opt-125M/model.py
+++ b/e2eshark/pytorch/models/opt-125M/model.py
@@ -1,7 +1,10 @@
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
 from transformers import OPTForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/opt-125m-gptq/model.py
+++ b/e2eshark/pytorch/models/opt-125m-gptq/model.py
@@ -1,7 +1,11 @@
-import sys, argparse
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer, GPTQConfig
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/opt-350m/model.py
+++ b/e2eshark/pytorch/models/opt-350m/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import OPTForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/phi-1_5/model.py
+++ b/e2eshark/pytorch/models/phi-1_5/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/phi-2/model.py
+++ b/e2eshark/pytorch/models/phi-2/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/resnet50/model.py
+++ b/e2eshark/pytorch/models/resnet50/model.py
@@ -1,7 +1,11 @@
-import sys, os
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from torchvision.models import resnet50, ResNet50_Weights
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
+++ b/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/t5-base/model.py
+++ b/e2eshark/pytorch/models/t5-base/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import T5Model, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/t5-large/model.py
+++ b/e2eshark/pytorch/models/t5-large/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import T5Model, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through
@@ -37,11 +35,11 @@ model = T5Model.from_pretrained(
 model.to("cpu")
 model.eval()
 tokenizer("Studies have been shown that owning a dog is good for you", **tokenization_kwargs)
-encoded_input_ids = tokenizer("Studies have been shown that owning a dog is good for you", 
-    **tokenization_kwargs
+encoded_input_ids = tokenizer(
+    "Studies have been shown that owning a dog is good for you", **tokenization_kwargs
 ).input_ids.cpu()
-decoder_input_ids = tokenizer("Studies show that", 
-    **tokenization_kwargs
+decoder_input_ids = tokenizer(
+    "Studies show that", **tokenization_kwargs
 ).input_ids.cpu()
 decoder_input_ids = model._shift_right(decoder_input_ids)
 attention_mask = torch.ones(1, 512).to("cpu")

--- a/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
+++ b/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
+import torch.nn
 from transformers import LlamaForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/vit-base-patch16-224/model.py
+++ b/e2eshark/pytorch/models/vit-base-patch16-224/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import ViTImageProcessor, ViTForImageClassification
 from PIL import Image
 import requests

--- a/e2eshark/pytorch/models/whisper-base/model.py
+++ b/e2eshark/pytorch/models/whisper-base/model.py
@@ -4,10 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
-import torch
-import torch.nn as nn
-import torch_mlir
+import sys
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/whisper-medium/model.py
+++ b/e2eshark/pytorch/models/whisper-medium/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/models/whisper-small/model.py
+++ b/e2eshark/pytorch/models/whisper-small/model.py
@@ -4,10 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
-import torch.nn as nn
-import torch_mlir
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 # import from e2eshark/tools to allow running in current dir, for run through

--- a/e2eshark/pytorch/operators/conv2d/model.py
+++ b/e2eshark/pytorch/operators/conv2d/model.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
 import torch.nn as nn
-import torch_mlir
 
 # import from e2eshark/tools to allow running in current dir, for run through
 # run.pl, commutils is symbolically linked to allow any rundir to work

--- a/e2eshark/pytorch/operators/gridsampler/model.py
+++ b/e2eshark/pytorch/operators/gridsampler/model.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
 import torch.nn as nn
-import torch_mlir
 
 # import from e2eshark/tools to allow running in current dir, for run through
 # run.pl, commutils is symbolically linked to allow any rundir to work

--- a/e2eshark/pytorch/operators/gridsampler2/model.py
+++ b/e2eshark/pytorch/operators/gridsampler2/model.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
 import torch.nn as nn
-import torch_mlir
 
 # import from e2eshark/tools to allow running in current dir, for run through
 # run.pl, commutils is symbolically linked to allow any rundir to work

--- a/e2eshark/pytorch/operators/silu/model.py
+++ b/e2eshark/pytorch/operators/silu/model.py
@@ -4,10 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import sys, argparse
+import sys
 import torch
 import torch.nn as nn
-import torch_mlir
 
 # import from e2eshark/tools to allow running in current dir, for run through
 # run.pl, commutils is symbolically linked to allow any rundir to work


### PR DESCRIPTION
Progress on https://github.com/nod-ai/SHARK-TestSuite/issues/49

According to my IDE and some local running, these imports were unused. The `import torch_mlir` lines are particularly problematic, as torch-mlir on its own is not distributed for downstream projects to use (there are nightly Linux packages for some developer use, but downstream projects like IREE take a source dependency on torch-mlir and ship their own packages).