### PR TITLE
Refresh docs and flags for importing from e2eshark to IREE.

### DIFF
--- a/iree_tests/README.md
+++ b/iree_tests/README.md
@@ -333,15 +333,31 @@ python ./iree_tests/onnx/import_tests.py
 > [!WARNING]
 > UNDER CONSTRUCTION - this will change!
 
-1. Setup venv for the [e2eshark/](/e2eshark/) directory by following that README
+1. Setup venv for the [e2eshark/](/e2eshark/) directory by following that README:
+
+    ```bash
+    e2eshark$ python -m venv .venv
+    e2eshark$ source .venv/bin/activate
+    e2eshark$ python -m pip install -r requirements.txt
+    e2eshark$ python -m pip install -e [PATH TO SHARK-Turbine REPO]/models
+    ```
+
+    Notes:
+
+    * You may need to comment out the torch-mlir install from `requirements.txt`
+      on non-Linux.
+    * You may need to downgrade numpy:
+
+        ```bash
+        pip uninstall numpy
+        pip install numpy<2.0
+        ```
 
 2. Run a test from e2eshark to generate artifact files:
 
     ```bash
     e2eshark$ python run.py \
       --cachedir ${CACHE_DIR} \
-      -c ${TORCH_MLIR_BUILD_DIR} \
-      -i ${IREE_BUILD_DIR} \
       --tests pytorch/models/resnet50 \
       --mode turbine
 
@@ -361,7 +377,7 @@ python ./iree_tests/onnx/import_tests.py
    into `iree_tests/`:
 
    ```bash
-   iree_tests$ python ./pytorch/models/export_from_e2eshark.py resnet50
+   iree_tests$ python ./pytorch/models/import_from_e2eshark.py --model=resnet50
    iree_tests$ ls ./pytorch/models/resnet50
 
    opt-125M.mlirbc  splats.irpa
@@ -383,7 +399,7 @@ python ./iree_tests/onnx/import_tests.py
 
 #### Generating model test cases from turbine/tank
 
-As seen in iree_tests/pytorch/models, there are some models with the "-tank" suffix.
+As seen in [`iree_tests/pytorch/models`](./pytorch/models/), there are some models with the "-tank" suffix.
 This refers to tests that were generated using the normal turbine flow.
 For custom models, such as sd, sdxl, or stateless_llama, you can clone the turbine repo
 and follow the setup instructions there (https://github.com/nod-ai/SHARK-Turbine).

--- a/iree_tests/pytorch/models/import_from_e2eshark.py
+++ b/iree_tests/pytorch/models/import_from_e2eshark.py
@@ -38,8 +38,8 @@ def extract_parameters(
     exec_args = [
         "iree-compile",
         str(input_mlir_path),
-        f"--iree-opt-parameter-archive-export-file={str(real_weights_output_path)}",
-        f"--iree-opt-splat-parameter-archive-export-file={str(splats_output_path)}",
+        f"--iree-opt-export-parameters={str(real_weights_output_path)}",
+        f"--iree-opt-splat-parameters={str(splats_output_path)}",
         "--compile-to=global-optimization",
         "-o",
         str(output_mlir_path),


### PR DESCRIPTION
This keeps the documentation up to date with instructions that worked on my Windows machine.

Unfortunately I wasn't able to regenerate test cases for resnet50 or opt-125M:

* resnet50 crashed in the compiler at `mlir::iree_compiler::IREE::Util::serializeResourceRawData D:\dev\projects\iree\compiler\src\iree\compiler\Dialect\Util\IR\UtilAttrs.cpp:230:0`
* opt-125M regressed in PyTorch at some point - I can't even export it to torch-mlir (marked as failing, along with nearly all other models, at https://github.com/nod-ai/e2eshark-reports/blob/main/2024-05-07/turbine_reports/statusreport.md)