### PR TITLE
Fix for calculating the number of elements in a zero rank tensor.

### DIFF
--- a/e2eshark/_run_helper.py
+++ b/e2eshark/_run_helper.py
@@ -175,7 +175,7 @@ def loadRawBinaryAsTorchSensor(binaryfile, shape, dtype):
     with open(binaryfile, "rb") as f:
         binarydata = f.read()
     # Number of elements in tensor
-    num_elem = torch.prod(torch.tensor(list(shape)))
+    num_elem = torch.prod(torch.tensor(list(shape), dtype=torch.int64))
     # Total bytes
     tensor_num_bytes = (num_elem * dtype.itemsize).item()
     barray = bytearray(binarydata[0:tensor_num_bytes])


### PR DESCRIPTION
num_elem was being calculated as a float, which was causing the bytearray() to fail, and the test to get silently dropped.

This fixes:
onnx/operators/DynamicQuantizeLinear
onnx/operators/DynamicQuantizeLinearCast