### PR TITLE
Add support for backend specific config files for sdxl models.

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -101,11 +101,15 @@ jobs:
           - name: cpu_llvm_sync
             runs-on: nodai-amdgpu-w7900-x86-64
             models-config-file: config_pytorch_models_cpu_llvm_task.json
-            sdxl-config-file: config_sdxl_scheduled_unet_cpu_llvm_task.json
+            sdxl-prompt-encoder-config-file: config_sdxl_prompt_encoder_cpu_llvm_task.json
+            sdxl-unet-config-file: config_sdxl_scheduled_unet_cpu_llvm_task.json
+            sdxl-vae-decode-config-file: config_sdxl_vae_decode_cpu_llvm_task.json
           - name: gpu_mi250_rocm
             runs-on: nodai-amdgpu-mi250-x86-64
             models-config-file: config_gpu_rocm_models.json
-            sdxl-config-file: config_sdxl_scheduled_unet_gpu_rocm.json
+            sdxl-prompt-encoder-config-file: config_sdxl_prompt_encoder_gpu_rocm.json
+            sdxl-unet-config-file: config_sdxl_scheduled_unet_gpu_rocm.json
+            sdxl-vae-decode-config-file: config_sdxl_vae_decode_gpu_rocm.json
     env:
       VENV_DIR: ${{ github.workspace }}/.venv
       IREE_TEST_FILES: ~/iree_tests_cache
@@ -157,7 +161,23 @@ jobs:
             --durations=0 \
             --config-files=${MODELS_CONFIG_FILE_PATH}
 
-      - name: "Running real weights SDXL tests"
+      - name: "Running real weights SDXL prompt encoder tests"
+        id: prompt_encode
+        if: ${{ !cancelled() }}
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-prompt-encoder-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=${SDXL_PROMPT_ENCODER_CONFIG_FILE_PATH}
+
+      - name: "Running real weights SDXL scheduled unet tests"
+        id: unet
         if: ${{ !cancelled() }}
         run: |
           source ${VENV_DIR}/bin/activate
@@ -169,10 +189,28 @@ jobs:
             --log-cli-level=info \
             --timeout=1200 \
             --durations=0 \
-            --config-files=${SDXL_CONFIG_FILE_PATH}
+            --config-files=${SDXL_UNET_CONFIG_FILE_PATH}
+      
+      - name: "Running real weights SDXL vae decode tests"
+        id: vae
+        if: ${{ !cancelled() }}
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-vae-decode-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=${SDXL_VAE_DECODE_CONFIG_FILE_PATH}
 
       - name: "Running SDXL ROCm pipeline benchmark"
         if: contains(matrix.name, 'rocm')
+        if: |
+          steps.prompt_encode.outcome == 'success' && 
+          steps.unet.outcome == 'success' && steps.vae.outcome == 'success'
         run: |
           source ${VENV_DIR}/bin/activate
           bash iree_tests/benchmarks/benchmark_sdxl_rocm.sh

--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -137,6 +137,19 @@ jobs:
             --durations=0 \
             --config-files=iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
 
+      - name: "Running real weight model tests - Prompt Encoder CPU"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-prompt-encoder-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=iree_tests/configs/config_sdxl_prompt_encoder_cpu_llvm_task.json
+
       - name: "Running real weight model tests - Scheduled UNet CPU"
         run: |
           source ${VENV_DIR}/bin/activate
@@ -149,6 +162,19 @@ jobs:
             --timeout=1200 \
             --durations=0 \
             --config-files=iree_tests/configs/config_sdxl_scheduled_unet_cpu_llvm_task.json
+      
+      - name: "Running real weight model tests - VAE Decode CPU"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-vae-decode-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=iree_tests/configs/config_sdxl_vae_decode_cpu_llvm_task.json
 
   linux_x86_64_mi250_gpu_models:
     name: Linux (x86_64 mi250) Models GPU
@@ -198,6 +224,19 @@ jobs:
             --timeout=1200 \
             --durations=0 \
             --config-files=iree_tests/configs/config_gpu_rocm_models.json
+      
+      - name: "Running real weight model tests - Prompt Encoder ROCm AMDGPU"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-prompt-encoder-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=iree_tests/configs/config_sdxl_prompt_encoder_gpu_rocm.json
 
       - name: "Running real weight model tests - Scheduled UNet ROCm AMDGPU"
         run: |
@@ -211,6 +250,19 @@ jobs:
             --timeout=1200 \
             --durations=0 \
             --config-files=iree_tests/configs/config_sdxl_scheduled_unet_gpu_rocm.json
+
+      - name: "Running real weight model tests - VAE Decode ROCm AMDGPU"
+        run: |
+          source ${VENV_DIR}/bin/activate
+          pytest iree_tests/pytorch/models/sdxl-vae-decode-tank \
+            -rpfE \
+            -k real_weights \
+            --no-skip-tests-missing-files \
+            --capture=no \
+            --log-cli-level=info \
+            --timeout=1200 \
+            --durations=0 \
+            --config-files=iree_tests/configs/config_sdxl_vae_decode_gpu_rocm.json
 
       - name: "Running SDXL rocm pipeline benchmark"
         run: |

--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -207,8 +207,8 @@ jobs:
             --config-files=${SDXL_VAE_DECODE_CONFIG_FILE_PATH}
 
       - name: "Running SDXL ROCm pipeline benchmark"
-        if: contains(matrix.name, 'rocm')
         if: |
+          contains(matrix.name, 'rocm') &&
           steps.prompt_encode.outcome == 'success' && 
           steps.unet.outcome == 'success' && steps.vae.outcome == 'success'
         run: |

--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -115,7 +115,9 @@ jobs:
       IREE_TEST_FILES: ~/iree_tests_cache
       IREE_TEST_PATH_EXTENSION: ${{ github.workspace }}/iree_tests/specs
       MODELS_CONFIG_FILE_PATH: iree_tests/configs/${{ matrix.models-config-file }}
-      SDXL_CONFIG_FILE_PATH: iree_tests/configs/${{ matrix.sdxl-config-file }}
+      SDXL_PROMPT_ENCODER_CONFIG_FILE_PATH: iree_tests/configs/${{ matrix.sdxl-prompt-encoder-config-file }}
+      SDXL_UNET_CONFIG_FILE_PATH: iree_tests/configs/${{ matrix.sdxl-unet-config-file }}
+      SDXL_VAE_DECODE_CONFIG_FILE_PATH: iree_tests/configs/${{ matrix.sdxl-vae-decode-config-file }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@v4

--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: cpu_llvm_sync
+          - name: cpu_llvm_task
             runs-on: nodai-amdgpu-w7900-x86-64
             models-config-file: config_pytorch_models_cpu_llvm_task.json
             sdxl-prompt-encoder-config-file: config_sdxl_prompt_encoder_cpu_llvm_task.json
@@ -164,7 +164,7 @@ jobs:
             --config-files=${MODELS_CONFIG_FILE_PATH}
 
       - name: "Running real weights SDXL prompt encoder tests"
-        id: prompt_encode
+        id: prompt_encoder
         if: ${{ !cancelled() }}
         run: |
           source ${VENV_DIR}/bin/activate
@@ -211,7 +211,7 @@ jobs:
       - name: "Running SDXL ROCm pipeline benchmark"
         if: |
           contains(matrix.name, 'rocm') &&
-          steps.prompt_encode.outcome == 'success' && 
+          steps.prompt_encoder.outcome == 'success' && 
           steps.unet.outcome == 'success' && steps.vae.outcome == 'success'
         run: |
           source ${VENV_DIR}/bin/activate

--- a/iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
+++ b/iree_tests/configs/config_pytorch_models_cpu_llvm_task.json
@@ -8,14 +8,14 @@
       "--device=local-task"
     ],
     "skip_compile_tests": [
-      "sdxl-scheduled-unet-3-tank"
+      "sdxl-scheduled-unet-3-tank",
+      "sdxl-vae-decode-tank",
+      "sdxl-prompt-encoder-tank"
     ],
     "skip_run_tests": [],
     "expected_compile_failures": [
       "opt-125M", // TODO(#17344): need to regenerate .mlirbc
       "resnet50", // TODO(#17344): need to regenerate .mlirbc
     ],
-    "expected_run_failures": [
-      "sdxl-vae-decode-tank",
-    ]
+    "expected_run_failures": []
   }

--- a/iree_tests/configs/config_sdxl_prompt_encoder_cpu_llvm_task.json
+++ b/iree_tests/configs/config_sdxl_prompt_encoder_cpu_llvm_task.json
@@ -1,0 +1,22 @@
+{
+    "config_name": "cpu_llvm_task",
+    "iree_compile_flags" : [
+      "--iree-hal-target-backends=llvm-cpu",
+      "--iree-llvmcpu-target-cpu-features=host"
+    ],
+    "iree_run_module_flags": [
+      "--device=local-task",
+      "--parameters=model=real_weights.irpa",
+      "--input=1x64xi64=@inference_input.0.bin",
+      "--input=1x64xi64=@inference_input.1.bin",
+      "--input=1x64xi64=@inference_input.2.bin",
+      "--input=1x64xi64=@inference_input.3.bin",
+      "--expected_output=2x64x2048xf16=@inference_output.0.bin",
+      "--expected_output=2x1280xf16=@inference_output.1.bin",
+      "--expected_f16_threshold=1.0f"
+    ],
+    "skip_compile_tests": [],
+    "skip_run_tests": [],
+    "expected_compile_failures": [],
+    "expected_run_failures": []
+}

--- a/iree_tests/configs/config_sdxl_prompt_encoder_gpu_rocm.json
+++ b/iree_tests/configs/config_sdxl_prompt_encoder_gpu_rocm.json
@@ -1,0 +1,24 @@
+{
+    "config_name": "gpu_rocm",
+    "iree_compile_flags" : [
+      "--iree-hal-target-backends=rocm",
+      "--iree-rocm-target-chip=gfx90a",
+      "--iree-opt-const-eval=false",
+      "--iree-codegen-transform-dialect-library=${IREE_TEST_PATH_EXTENSION}/attention_and_matmul_spec.mlir"
+    ],
+    "iree_run_module_flags": [
+      "--device=hip",
+      "--parameters=model=real_weights.irpa",
+      "--input=1x64xi64=@inference_input.0.bin",
+      "--input=1x64xi64=@inference_input.1.bin",
+      "--input=1x64xi64=@inference_input.2.bin",
+      "--input=1x64xi64=@inference_input.3.bin",
+      "--expected_output=2x64x2048xf16=@inference_output.0.bin",
+      "--expected_output=2x1280xf16=@inference_output.1.bin",
+      "--expected_f16_threshold=1.0f"
+    ],
+    "skip_compile_tests": [],
+    "skip_run_tests": [],
+    "expected_compile_failures": [],
+    "expected_run_failures": []
+}

--- a/iree_tests/configs/config_sdxl_scheduled_unet_gpu_rocm.json
+++ b/iree_tests/configs/config_sdxl_scheduled_unet_gpu_rocm.json
@@ -26,7 +26,7 @@
       "--input=2x1280xf16=@inference_input.2.bin",
       "--input=1xf16=@inference_input.3.bin",
       "--expected_output=1x4x128x128xf16=@inference_output.0.bin",
-      "--expected_f16_threshold=0.8f"
+      "--expected_f16_threshold=0.7f"
     ],
     "skip_compile_tests": [],
     "skip_run_tests": [],

--- a/iree_tests/configs/config_sdxl_vae_decode_cpu_llvm_task.json
+++ b/iree_tests/configs/config_sdxl_vae_decode_cpu_llvm_task.json
@@ -1,0 +1,20 @@
+{
+    "config_name": "cpu_llvm_task",
+    "iree_compile_flags" : [
+      "--iree-hal-target-backends=llvm-cpu",
+      "--iree-llvmcpu-target-cpu-features=host"
+    ],
+    "iree_run_module_flags": [
+      "--device=local-task",
+      "--parameters=model=real_weights.irpa",
+      "--input=1x4x128x128xf16=@inference_input.0.bin",
+      "--expected_output=1x3x1024x1024xf16=@inference_output.0.bin",
+      "--expected_f16_threshold=0.02f"
+    ],
+    "skip_compile_tests": [],
+    "skip_run_tests": [],
+    "expected_compile_failures": [],
+    "expected_run_failures": [
+      "sdxl-vae-decode-tank"
+    ]
+}

--- a/iree_tests/configs/config_sdxl_vae_decode_gpu_rocm.json
+++ b/iree_tests/configs/config_sdxl_vae_decode_gpu_rocm.json
@@ -7,17 +7,14 @@
       "--iree-codegen-transform-dialect-library=${IREE_TEST_PATH_EXTENSION}/attention_and_matmul_spec.mlir"
     ],
     "iree_run_module_flags": [
-      "--device=hip"
+      "--device=hip",
+      "--parameters=model=real_weights.irpa",
+      "--input=1x4x128x128xf16=@inference_input.0.bin",
+      "--expected_output=1x3x1024x1024xf16=@inference_output.0.bin",
+      "--expected_f16_threshold=0.015f"
     ],
-    "skip_compile_tests": [
-      "sdxl-scheduled-unet-3-tank",
-      "sdxl-vae-decode-tank",
-      "sdxl-prompt-encoder-tank"
-    ],
+    "skip_compile_tests": [],
     "skip_run_tests": [],
-    "expected_compile_failures": [
-      "opt-125M", // TODO(#17344): need to regenerate .mlirbc
-      "resnet50",
-    ],
+    "expected_compile_failures": [],
     "expected_run_failures": []
 }

--- a/iree_tests/pytorch/models/sdxl-prompt-encoder-tank/real_weights_data_flags.txt
+++ b/iree_tests/pytorch/models/sdxl-prompt-encoder-tank/real_weights_data_flags.txt
@@ -1,8 +1,0 @@
---parameters=model=real_weights.irpa
---input=1x64xi64=@inference_input.0.bin
---input=1x64xi64=@inference_input.1.bin
---input=1x64xi64=@inference_input.2.bin
---input=1x64xi64=@inference_input.3.bin
---expected_output=2x64x2048xf16=@inference_output.0.bin
---expected_output=2x1280xf16=@inference_output.1.bin
---expected_f16_threshold=1.0f

--- a/iree_tests/pytorch/models/sdxl-vae-decode-tank/real_weights_data_flags.txt
+++ b/iree_tests/pytorch/models/sdxl-vae-decode-tank/real_weights_data_flags.txt
@@ -1,4 +1,0 @@
---parameters=model=real_weights.irpa
---input=1x4x128x128xf16=@inference_input.0.bin
---expected_output=1x3x1024x1024xf16=@inference_output.0.bin
---expected_f16_threshold=0.02f


### PR DESCRIPTION
This commit adds support so that we can have different configuration files based on the backend for every sdxl model. This now gives us model and backend independence for all flags in sdxl