### PR TITLE
Skip installing torch-mlir automatically on non-Linux.

### DIFF
--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -12,9 +12,8 @@ accelerate
 auto-gptq
 optimum
 azure-storage-blob
-# install nightly build of torch_mlir 
--f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
-torch-mlir
+# install nightly build of torch_mlir, if on Linux (no macOS or Windows nightly builds)
+torch-mlir ; sys_platform == "linux" -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
 # install nightly build of iree-compiler and iree-runtime
 iree-compiler -f https://iree.dev/pip-release-links.html
 iree-runtime -f https://iree.dev/pip-release-links.html

--- a/iree_tests/README.md
+++ b/iree_tests/README.md
@@ -344,8 +344,6 @@ python ./iree_tests/onnx/import_tests.py
 
     Notes:
 
-    * You may need to comment out the torch-mlir install from `requirements.txt`
-      on non-Linux.
     * You may need to downgrade numpy:
 
         ```bash


### PR DESCRIPTION
Follow-up to https://github.com/nod-ai/SHARK-TestSuite/pull/231 and https://github.com/nod-ai/SHARK-TestSuite/pull/232.

Some parts of e2eshark won't work without standalone torch-mlir packages, but this helps users on macOS and Windows follow the setup instructions as-is to run the parts that do work (e.g. turbine).