### PR TITLE
Add missing `import torch` to turbinemodel stub.

### DIFF
--- a/e2eshark/tools/stubs/turbinemodel.py
+++ b/e2eshark/tools/stubs/turbinemodel.py
@@ -9,6 +9,7 @@
 
 import argparse
 import pickle
+import torch
 
 from turbine_models.model_builder import HFTransformerBuilder
 import shark_turbine.aot as aot


### PR DESCRIPTION
See https://github.com/nod-ai/SHARK-TestSuite/pull/231#discussion_r1621444654. This fixes

```
Traceback (most recent call last):
  File "D:\dev\projects\SHARK-TestSuite\e2eshark\test-run\pytorch\models\opt-125M\runmodel.py", line 145, in <module>
    torch.save(E2ESHARK_CHECK["input"], inputsavefilename)
    ^^^^^
NameError: name 'torch' is not defined
```

Individual model files had this import but did not use it directly. Imports should be added where they are used.