### PR TITLE
Encode tokenizer outputs as utf8 before printing them.

### DIFF
--- a/e2eshark/pytorch/models/bart-large/model.py
+++ b/e2eshark/pytorch/models/bart-large/model.py
@@ -43,7 +43,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/bert-large-uncased/model.py
+++ b/e2eshark/pytorch/models/bert-large-uncased/model.py
@@ -41,7 +41,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
+++ b/e2eshark/pytorch/models/bge-base-en-v1.5/model.py
@@ -41,7 +41,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/gemma-7b/model.py
+++ b/e2eshark/pytorch/models/gemma-7b/model.py
@@ -45,7 +45,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/gpt2-xl/model.py
+++ b/e2eshark/pytorch/models/gpt2-xl/model.py
@@ -40,7 +40,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/gpt2/model.py
+++ b/e2eshark/pytorch/models/gpt2/model.py
@@ -40,7 +40,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-GPTQ/model.py
@@ -45,7 +45,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/llama2-7b-hf/model.py
+++ b/e2eshark/pytorch/models/llama2-7b-hf/model.py
@@ -45,7 +45,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
+++ b/e2eshark/pytorch/models/miniLM-L12-H384-uncased/model.py
@@ -41,7 +41,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/opt-1.3b/model.py
+++ b/e2eshark/pytorch/models/opt-1.3b/model.py
@@ -43,7 +43,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/opt-125M/model.py
+++ b/e2eshark/pytorch/models/opt-125M/model.py
@@ -40,7 +40,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/opt-125m-gptq/model.py
+++ b/e2eshark/pytorch/models/opt-125m-gptq/model.py
@@ -45,7 +45,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/opt-350m/model.py
+++ b/e2eshark/pytorch/models/opt-350m/model.py
@@ -40,7 +40,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/phi-1_5/model.py
+++ b/e2eshark/pytorch/models/phi-1_5/model.py
@@ -43,7 +43,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/phi-2/model.py
+++ b/e2eshark/pytorch/models/phi-2/model.py
@@ -43,7 +43,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
+++ b/e2eshark/pytorch/models/stablelm-3b-4e1t/model.py
@@ -40,7 +40,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
+++ b/e2eshark/pytorch/models/vicuna-13b-v1.3/model.py
@@ -44,7 +44,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/whisper-base/model.py
+++ b/e2eshark/pytorch/models/whisper-base/model.py
@@ -41,7 +41,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/whisper-medium/model.py
+++ b/e2eshark/pytorch/models/whisper-medium/model.py
@@ -44,7 +44,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for

--- a/e2eshark/pytorch/models/whisper-small/model.py
+++ b/e2eshark/pytorch/models/whisper-small/model.py
@@ -44,7 +44,7 @@ model_response = model.generate(
     temperature=1.0,
 )
 print("Prompt:", prompt)
-print("Response:", tokenizer.decode(model_response[0]))
+print("Response:", tokenizer.decode(model_response[0]).encode("utf-8"))
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 # For geneartive AI models, input is int and should be kept that way for


### PR DESCRIPTION
Fixes https://github.com/nod-ai/SHARK-TestSuite/issues/105

These tokenizers sometimes output characters that cause trouble when printing with the default encoding on Windows, so explicitly encode as utf8. Not all tests currently generate such characters, but the extra safety seems helpful.

Sample response from whisper-small: `Response: b'<|startoftranscript|><|notimestamps|>What is nature of our existence?<|endoftext|>\xef\xbf\xbd\xef\xbf\xbd<|zh|>\xd0\xb7\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xe5\x84\x89\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd<|endoftext|>'`
* `UnicodeEncodeError: 'charmap' codec can't encode characters in position 82-83: character maps to <undefined>` (those are the `\xef\xbf` characters, unicode "replacement characters": https://stackoverflow.com/a/11162470, https://en.wikipedia.org/wiki/Specials_%28Unicode_block%29)

An alternate approach is to set the environment variable `PYTHONIOENCODING=utf-8` or `PYTHONUTF8=1`.