### PR TITLE
Update turbine mode to use latest SHARK setup.

### DIFF
--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -12,35 +12,28 @@ on:
    - cron: '0 12 * * *'
 
 jobs:
-  SHARK-Turbine:
-    runs-on: nodai-amdgpu-mi250-x86-64
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          repository: nod-ai/SHARK-Turbine
-          path: SHARK-Turbine
-  
-  iree-turbine:
-    runs-on: nodai-amdgpu-mi250-x86-64
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          repository: iree-org/iree-turbine
-          path: iree-turbine
-
   e2eshark:
-    needs: [turbine]
     runs-on: nodai-amdgpu-mi250-x86-64
     env:
       E2E_VENV_DIR: ${{ github.workspace }}/test-suite_venv
     steps:
-      - name: Checkout repo
+      - name: Checkout Test Suite
         uses: actions/checkout@v2
         with:
           repository: nod-ai/SHARK-TestSuite
           path: test-suite
+
+      - name: Checkout SHARK Turbine
+        uses: actions/checkout@v2
+        with:
+          repository: nod-ai/SHARK-Turbine
+          path: SHARK-Turbine
+
+      - name: Checkout iree turbine
+        uses: actions/checkout@v2
+        with:
+          repository: iree-org/iree-turbine
+          path: iree-turbine
 
       - name: "Setup e2eshark python venv"
         run: |

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -12,15 +12,23 @@ on:
    - cron: '0 12 * * *'
 
 jobs:
-  turbine:
+  SHARK-Turbine:
     runs-on: nodai-amdgpu-mi250-x86-64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           repository: nod-ai/SHARK-Turbine
-          ref: torch_2.1
-          path: turbine
+          path: SHARK-Turbine
+  
+  iree-tubrine:
+    runs-on: nodai-amdgpu-mi250-x86-64
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          repository: iree-org/iree-turbine
+          path: iree-turbine
 
   e2eshark:
     needs: [turbine]
@@ -76,18 +84,11 @@ jobs:
 
       - name: Setup turbine python venv
         run: |
-          python3.11 -m venv ${TURBINE_VENV_DIR}
-          source ${TURBINE_VENV_DIR}/bin/activate
-          pip install --upgrade pip
-          pip install --index-url https://download.pytorch.org/whl/cpu \
-            -r ../turbine/core/pytorch-cpu-requirements.txt \
-            -r ../turbine/core/torchvision-requirements.txt
-          pip install --upgrade -r ../turbine/core/requirements.txt
-          pip install -e ../turbine/core[testing]
-          pip install -e ../turbine/models
-          pip install -r ./e2eshark/ci-requirements.txt
-          pip uninstall -y transformers
-          pip install transformers -U
+          source ${E2E_VENV_DIR}/bin/activate
+          pip install -f https://iree.dev/pip-release-links.html --upgrade \
+          -r ../iree-turbine/iree-requirements.txt
+          pip install -e ../iree-turbine[testing]
+          pip install -e ../SHARK-Turbine/models
         working-directory: ./test-suite
 
       - name: Run Turbine Mode

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -21,7 +21,7 @@ jobs:
           repository: nod-ai/SHARK-Turbine
           path: SHARK-Turbine
   
-  iree-tubrine:
+  iree-turbine:
     runs-on: nodai-amdgpu-mi250-x86-64
     steps:
       - name: Checkout repo
@@ -35,7 +35,6 @@ jobs:
     runs-on: nodai-amdgpu-mi250-x86-64
     env:
       E2E_VENV_DIR: ${{ github.workspace }}/test-suite_venv
-      TURBINE_VENV_DIR: ${{ github.workspace }}/turbine_venv
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -93,7 +92,7 @@ jobs:
 
       - name: Run Turbine Mode
         run: |
-          source ${TURBINE_VENV_DIR}/bin/activate
+          source ${E2E_VENV_DIR}/bin/activate
           cd e2eshark
           free -mh
           HF_TOKEN=${{ secrets.HF_TOKEN }} python3.11 ./run.py \

--- a/e2eshark/README.md
+++ b/e2eshark/README.md
@@ -198,11 +198,15 @@ If you are also interested in running through SHARK-Turbine follow these instruc
 git clone https://github.com/nod-ai/SHARK-Turbine
 ```
 
+```bash
+git clone https://github.com/iree-org/iree-turbine
+```
+
 Now, go back to the TestSuite Repo, and make sure you are using same venv from all previous steps.
 
 ```bash
-pip install -f https://iree.dev/pip-release-links.html --upgrade -r 'your local SHARK Turbine repo'/core/iree-requirements.txt
-pip install -e 'your local SHARK Turbine repo'/core[testing]
+pip install -f https://iree.dev/pip-release-links.html --upgrade -r 'your local iree turbine repo'/iree-requirements.txt
+pip install -e 'your local iree turbine repo'[testing]
 pip install -e 'your local SHARK Turbine repo'/models
 ```
 

--- a/e2eshark/requirements.txt
+++ b/e2eshark/requirements.txt
@@ -13,7 +13,8 @@ auto-gptq
 optimum
 azure-storage-blob
 # install nightly build of torch_mlir, if on Linux (no macOS or Windows nightly builds)
-torch-mlir ; sys_platform == "linux" -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+-f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+torch-mlir ; sys_platform == "linux"
 # install nightly build of iree-compiler and iree-runtime
 iree-compiler -f https://iree.dev/pip-release-links.html
 iree-runtime -f https://iree.dev/pip-release-links.html


### PR DESCRIPTION
This commit updates the workflow and readme to use both the repos and latest dependencies, so we are no longer pinned to torch 2.1.