### PR TITLE
onnx `model.py` fix

### DIFF
--- a/e2eshark/onnx/models/DeepLabV3_resnet50_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/DeepLabV3_resnet50_vaiq_int8/model.py
@@ -33,9 +33,9 @@ outputs = session.get_outputs()
 
 
 model_output = session.run(
-    [outputs[0].name],
+    [outputs[0].name, outputs[1].name],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 

--- a/e2eshark/onnx/models/FCN_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/FCN_vaiq_int8/model.py
@@ -35,7 +35,7 @@ outputs = session.get_outputs()
 model_output = session.run(
     [outputs[0].name, outputs[1].name],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 

--- a/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/RAFT_vaiq_int8/model.py
@@ -48,12 +48,12 @@ model_output = session.run(
         inputs[0].name: model_input_X,
         inputs[1].name: model_input_Y
     },
-)[0]
-E2ESHARK_CHECK["inputs"] = [torch.from_numpy(model_input_X), torch.from_numpy(model_input_Y)]
-E2ESHARK_CHECK["outputs"] = [torch.from_numpy(arr) for arr in model_output]
+)
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X), torch.from_numpy(model_input_Y)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
-print("Input:", E2ESHARK_CHECK["inputs"])
-print("Output:", E2ESHARK_CHECK["outputs"])
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
 
 # Post process output to do:
 # sort(topk(torch.nn.functional.softmax(output, 0), 2)[1])[0]

--- a/e2eshark/onnx/models/U-2-Net_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/U-2-Net_vaiq_int8/model.py
@@ -40,7 +40,7 @@ model_output = session.run(
         outputs[6].name,
     ],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 

--- a/e2eshark/onnx/models/YoloNetV3_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/YoloNetV3_vaiq_int8/model.py
@@ -32,7 +32,7 @@ outputs = session.get_outputs()
 model_output = session.run(
     [outputs[0].name],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 

--- a/e2eshark/onnx/models/u-net_brain_mri_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/u-net_brain_mri_vaiq_int8/model.py
@@ -32,7 +32,7 @@ outputs = session.get_outputs()
 model_output = session.run(
     [outputs[0].name],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 

--- a/e2eshark/onnx/models/yolov8n_vaiq_int8/model.py
+++ b/e2eshark/onnx/models/yolov8n_vaiq_int8/model.py
@@ -32,7 +32,7 @@ outputs = session.get_outputs()
 model_output = session.run(
     [outputs[0].name, outputs[1].name, outputs[2].name, outputs[3].name],
     {inputs[0].name: model_input_X},
-)[0]
+)
 E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
 E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 


### PR DESCRIPTION
https://github.com/nod-ai/SHARK-Turbine/issues/683
When using iree with local changes that fixed `iree-compile` compilation errors, the test started to fail in inference (`iree-run-module`). I was specifically running the RAFT test. This seemed to be due to accessing `E2ESHARK_CHECK` with "inputs" instead of "input".
After fixing that I got a different inference error due to a mismatch between expected outputs and the outputs of the vmfb. I grepped  `OUT_OF_RANGE` and found other tests failing in the same way (found in model's `inference.log` file). There could be other tests that are failing earlier than inference that have this same issue.