### PR TITLE
Run IREE Test Suite on a nightly schedule.

### DIFF
--- a/.github/workflows/test_iree.yml
+++ b/.github/workflows/test_iree.yml
@@ -6,7 +6,6 @@
 
 name: IREE Test Suite
 on:
-  # TODO(scotttodd): run on schedule (nightly), and/or on pushes to `main`
   pull_request:
     paths:
       # This file itself.
@@ -16,6 +15,9 @@ on:
       # The iree_special_models subproject.
       - "iree_special_models/**"
   workflow_dispatch:
+  schedule:
+    # Runs at 3:00 PM UTC, which is 8:00 AM PST
+    - cron: "0 15 * * *"
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -165,7 +167,7 @@ jobs:
             --timeout=1200 \
             --durations=0 \
             --config-files=${MODELS_CONFIG_FILE_PATH}
-      
+
       - name: "Running SDXL special model tests"
         id: special_models_sdxl
         if: ${{ !cancelled() }}
@@ -178,7 +180,7 @@ jobs:
             --log-cli-level=info \
             --timeout=1200 \
             --durations=0
-      
+
       - name: "Running SD3 special model tests"
         id: special_models_sd3
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Might as well have this running on a schedule so we can compare results on PRs to a baseline.

I chose 8AM PST since IREE nightly releases typically finish building around 6:45AM PST (see times on https://github.com/iree-org/iree/actions/workflows/validate_and_publish_release.yml)