### PR TITLE
Switch punet tests to use .mlir and .irpa files from Hugging Face.

### DIFF
--- a/iree_tests/download_remote_files.py
+++ b/iree_tests/download_remote_files.py
@@ -172,7 +172,9 @@ def download_huggingface_remote_file(
     #   repo_id:  SlyEcho/open_llama_3b_v2_gguf
     #   revision: main
     #   filename: open-llama-3b-v2-q4_0.gguf
-    result = re.search(r"https://huggingface.co/(.+)/resolve/(.+)/(.+)", remote_file)
+    result = re.search(
+        r"https://huggingface.co/(.+)/resolve/([^\/]+)/(.+)", remote_file
+    )
     repo_id = result.groups()[0]
     revision = result.groups()[1]
     filename = result.groups()[2]

--- a/iree_tests/sharktank/punet/.gitignore
+++ b/iree_tests/sharktank/punet/.gitignore
@@ -1,0 +1,4 @@
+# Model source files are downloaded from
+# https://huggingface.co/amd-shark/sdxl-quant-models, not stored in Git LFS.
+*.mlirbc
+*.mlir

--- a/iree_tests/sharktank/punet/fp16/real_weights_data_flags.txt
+++ b/iree_tests/sharktank/punet/fp16/real_weights_data_flags.txt
@@ -1,4 +1,4 @@
---parameters=model=sdxl_fp16_dataset.irpa
+--parameters=model=sdxl_unet_fp16_dataset.irpa
 --input=1x4x128x128xf16
 --input=1xi32
 --input=2x64x2048xf16

--- a/iree_tests/sharktank/punet/fp16/sdxl_fp16_export_mlir.mlirbc
+++ b/iree_tests/sharktank/punet/fp16/sdxl_fp16_export_mlir.mlirbc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0987d40ba5caf980871c72e243314341ef607f3063ccccb090d01fa430898e8
-size 873009

--- a/iree_tests/sharktank/punet/fp16/test_cases.json
+++ b/iree_tests/sharktank/punet/fp16/test_cases.json
@@ -5,7 +5,8 @@
       "name": "real_weights",
       "runtime_flagfile": "real_weights_data_flags.txt",
       "remote_files": [
-        "https://sharkpublic.blob.core.windows.net/sharkpublic/scotttodd/iree_tests/2024_07_02/sdxl_fp16_dataset.irpa",
+        "https://huggingface.co/amd-shark/sdxl-quant-models/resolve/fe57fe12eeb6eac83f469793984f6ad4c06a478c/unet/fp16/export/sdxl_unet_fp16_dataset.irpa",
+        "https://huggingface.co/amd-shark/sdxl-quant-models/resolve/fe57fe12eeb6eac83f469793984f6ad4c06a478c/unet/fp16/export/sdxl_unet_fp16_export.mlir"
         // TODO: files for real inputs and real expected outputs
       ]
     }

--- a/iree_tests/sharktank/punet/int8/real_weights_data_flags.txt
+++ b/iree_tests/sharktank/punet/int8/real_weights_data_flags.txt
@@ -1,4 +1,4 @@
---parameters=model=sdxl_int8_dataset.irpa
+--parameters=model=sdxl_unet_int8_dataset.irpa
 --input=1x4x128x128xf16
 --input=1xi32
 --input=2x64x2048xf16

--- a/iree_tests/sharktank/punet/int8/sdxl_int8_export_mlir.mlirbc
+++ b/iree_tests/sharktank/punet/int8/sdxl_int8_export_mlir.mlirbc
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:180d88507c1b75e3e80e65cdd192de8af6e9c70961717d45ceb33194de4d3ad7
-size 2362168

--- a/iree_tests/sharktank/punet/int8/test_cases.json
+++ b/iree_tests/sharktank/punet/int8/test_cases.json
@@ -5,7 +5,8 @@
       "name": "real_weights",
       "runtime_flagfile": "real_weights_data_flags.txt",
       "remote_files": [
-        "https://sharkpublic.blob.core.windows.net/sharkpublic/scotttodd/iree_tests/2024_07_02/sdxl_int8_dataset.irpa",
+        "https://huggingface.co/amd-shark/sdxl-quant-models/resolve/fe57fe12eeb6eac83f469793984f6ad4c06a478c/unet/int8/export/sdxl_unet_int8_dataset.irpa",
+        "https://huggingface.co/amd-shark/sdxl-quant-models/resolve/fe57fe12eeb6eac83f469793984f6ad4c06a478c/unet/int8/export/sdxl_unet_int8_export.mlir"
         // TODO: files for real inputs and real expected outputs
       ]
     }


### PR DESCRIPTION
See https://huggingface.co/amd-shark/sdxl-quant-models, which is now a source of truth for developers interfacing with this model. For now the files are pinned to a commit hash as changes are expected over the coming days.

Some details:

* I needed to update the regex in `download_remote_files.py` to support subdirectories. The `/` search was greedy, capturing e.g. `fe57fe12eeb6eac83f469793984f6ad4c06a478c/unet/fp16/export` and `sdxl_unet_fp16_dataset.irpa` instead of `fe57fe12eeb6eac83f469793984f6ad4c06a478c` and `unet/fp16/export/sdxl_unet_fp16_dataset.irpa`.
* This benefits from https://github.com/nod-ai/SHARK-TestSuite/pull/282, since the `.mlir` file that the test collector looks for is a remote file not downloaded with a regular Git [LFS] checkout. That PR changes the collector to look for `test_cases.json` instead of `.mlir` files.