### PR TITLE
Adjust schedule for test_e2eshark nightly run.

### DIFF
--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -8,8 +8,8 @@ name: E2ESHARK Test Suite
 on:
   workflow_dispatch:
   schedule:
-  # Runs at 12:00 PM UTC, which is 5:00 AM PST
-   - cron: '0 12 * * *'
+    # Runs at 8:00 AM UTC, which is 1:00 AM PST
+    - cron: "0 8 * * *"
 
 jobs:
   e2eshark:
@@ -100,7 +100,7 @@ jobs:
           --ci \
           -v
         working-directory: ./test-suite
-      
+
       - uses: actions/upload-artifact@master
         with:
           name: ci_reports
@@ -114,10 +114,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nod-ai/e2eshark-reports
-          ref: 'main'
+          ref: "main"
           token: ${{ secrets.E2ESHARK_GITHUB_TOKEN }}
           path: e2eshark-reports
-      
+
       - uses: actions/download-artifact@master
         with:
           name: ci_reports


### PR DESCRIPTION
This job is hogging the CI runner during PST working hours: https://github.com/nod-ai/SHARK-TestSuite/actions/runs/9856657975/job/27214130493, so start it earlier in the morning.

The workflow history also shows the runs taking 5-6 hours but only running for 3 hours? https://github.com/nod-ai/SHARK-TestSuite/actions/workflows/test_e2eshark.yml. Is the machine offline or busy during that time? Moving the schedule might not help in that case.