### PR TITLE
Add p0/p1 486 onnx model.py

### DIFF
--- a/e2eshark/onnx/models/adv_inception_v3/model.py
+++ b/e2eshark/onnx/models/adv_inception_v3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_focus_l/model.py
+++ b/e2eshark/onnx/models/cs3darknet_focus_l/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_focus_l_train/model.py
+++ b/e2eshark/onnx/models/cs3darknet_focus_l_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_focus_m/model.py
+++ b/e2eshark/onnx/models/cs3darknet_focus_m/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_focus_m_train/model.py
+++ b/e2eshark/onnx/models/cs3darknet_focus_m_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_l/model.py
+++ b/e2eshark/onnx/models/cs3darknet_l/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_l_train/model.py
+++ b/e2eshark/onnx/models/cs3darknet_l_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_m/model.py
+++ b/e2eshark/onnx/models/cs3darknet_m/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_m_train/model.py
+++ b/e2eshark/onnx/models/cs3darknet_m_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_x/model.py
+++ b/e2eshark/onnx/models/cs3darknet_x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3darknet_x_train/model.py
+++ b/e2eshark/onnx/models/cs3darknet_x_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3edgenet_x/model.py
+++ b/e2eshark/onnx/models/cs3edgenet_x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3edgenet_x_train/model.py
+++ b/e2eshark/onnx/models/cs3edgenet_x_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3se_edgenet_x/model.py
+++ b/e2eshark/onnx/models/cs3se_edgenet_x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3se_edgenet_x_train/model.py
+++ b/e2eshark/onnx/models/cs3se_edgenet_x_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3sedarknet_l/model.py
+++ b/e2eshark/onnx/models/cs3sedarknet_l/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3sedarknet_l_train/model.py
+++ b/e2eshark/onnx/models/cs3sedarknet_l_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3sedarknet_x/model.py
+++ b/e2eshark/onnx/models/cs3sedarknet_x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cs3sedarknet_x_train/model.py
+++ b/e2eshark/onnx/models/cs3sedarknet_x_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cspdarknet53/model.py
+++ b/e2eshark/onnx/models/cspdarknet53/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cspresnet50/model.py
+++ b/e2eshark/onnx/models/cspresnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/cspresnext50/model.py
+++ b/e2eshark/onnx/models/cspresnext50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenet121/model.py
+++ b/e2eshark/onnx/models/densenet121/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenet121_test/model.py
+++ b/e2eshark/onnx/models/densenet121_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenet161/model.py
+++ b/e2eshark/onnx/models/densenet161/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenet169/model.py
+++ b/e2eshark/onnx/models/densenet169/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenetblur121d/model.py
+++ b/e2eshark/onnx/models/densenetblur121d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/densenetblur121d_test/model.py
+++ b/e2eshark/onnx/models/densenetblur121d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla102/model.py
+++ b/e2eshark/onnx/models/dla102/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla102x/model.py
+++ b/e2eshark/onnx/models/dla102x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla102x2/model.py
+++ b/e2eshark/onnx/models/dla102x2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla169/model.py
+++ b/e2eshark/onnx/models/dla169/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla34/model.py
+++ b/e2eshark/onnx/models/dla34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla46_c/model.py
+++ b/e2eshark/onnx/models/dla46_c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla46x_c/model.py
+++ b/e2eshark/onnx/models/dla46x_c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla60/model.py
+++ b/e2eshark/onnx/models/dla60/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla60_res2net/model.py
+++ b/e2eshark/onnx/models/dla60_res2net/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla60_res2next/model.py
+++ b/e2eshark/onnx/models/dla60_res2next/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla60x/model.py
+++ b/e2eshark/onnx/models/dla60x/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla60x_c/model.py
+++ b/e2eshark/onnx/models/dla60x_c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dm_nfnet_f0.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f0.dm_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dm_nfnet_f0.dm_in1k_train/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f0.dm_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dm_nfnet_f1.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f1.dm_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dm_nfnet_f1.dm_in1k_train/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f1.dm_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn107/model.py
+++ b/e2eshark/onnx/models/dpn107/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn131/model.py
+++ b/e2eshark/onnx/models/dpn131/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn68/model.py
+++ b/e2eshark/onnx/models/dpn68/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn68b/model.py
+++ b/e2eshark/onnx/models/dpn68b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn68b_test/model.py
+++ b/e2eshark/onnx/models/dpn68b_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn92/model.py
+++ b/e2eshark/onnx/models/dpn92/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dpn98/model.py
+++ b/e2eshark/onnx/models/dpn98/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l0.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l0.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l0.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l0.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l1.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l1.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l1.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l1.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l2.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l2.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_nfnet_l2.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/eca_nfnet_l2.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_resnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/eca_resnet33ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_resnet33ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/eca_resnet33ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_resnext26ts.ch_in1k/model.py
+++ b/e2eshark/onnx/models/eca_resnext26ts.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/eca_resnext26ts.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/eca_resnext26ts.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet101d/model.py
+++ b/e2eshark/onnx/models/ecaresnet101d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet101d_pruned/model.py
+++ b/e2eshark/onnx/models/ecaresnet101d_pruned/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet101d_pruned_test/model.py
+++ b/e2eshark/onnx/models/ecaresnet101d_pruned_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet101d_test/model.py
+++ b/e2eshark/onnx/models/ecaresnet101d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet26t/model.py
+++ b/e2eshark/onnx/models/ecaresnet26t/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet26t_train/model.py
+++ b/e2eshark/onnx/models/ecaresnet26t_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50d/model.py
+++ b/e2eshark/onnx/models/ecaresnet50d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50d_pruned/model.py
+++ b/e2eshark/onnx/models/ecaresnet50d_pruned/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50d_pruned_test/model.py
+++ b/e2eshark/onnx/models/ecaresnet50d_pruned_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50d_test/model.py
+++ b/e2eshark/onnx/models/ecaresnet50d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50t/model.py
+++ b/e2eshark/onnx/models/ecaresnet50t/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnet50t_train/model.py
+++ b/e2eshark/onnx/models/ecaresnet50t_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnetlight/model.py
+++ b/e2eshark/onnx/models/ecaresnetlight/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ecaresnetlight_test/model.py
+++ b/e2eshark/onnx/models/ecaresnetlight_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ens_adv_inception_resnet_v2/model.py
+++ b/e2eshark/onnx/models/ens_adv_inception_resnet_v2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ese_vovnet19b_dw/model.py
+++ b/e2eshark/onnx/models/ese_vovnet19b_dw/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ese_vovnet19b_dw_test/model.py
+++ b/e2eshark/onnx/models/ese_vovnet19b_dw_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ese_vovnet39b/model.py
+++ b/e2eshark/onnx/models/ese_vovnet39b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ese_vovnet39b_test/model.py
+++ b/e2eshark/onnx/models/ese_vovnet39b_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_b.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetv3_b.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_b.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/fbnetv3_b.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_d.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetv3_d.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_d.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/fbnetv3_d.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_g.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetv3_g.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetv3_g.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/fbnetv3_g.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gc_efficientnetv2_rw_t.agc_in1k/model.py
+++ b/e2eshark/onnx/models/gc_efficientnetv2_rw_t.agc_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gc_efficientnetv2_rw_t.agc_in1k_train/model.py
+++ b/e2eshark/onnx/models/gc_efficientnetv2_rw_t.agc_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/gcresnet33ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnet33ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/gcresnet33ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnet50t.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/gcresnet50t.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnet50t.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/gcresnet50t.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnext26ts.ch_in1k/model.py
+++ b/e2eshark/onnx/models/gcresnext26ts.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnext26ts.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/gcresnext26ts.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnext50ts.ch_in1k/model.py
+++ b/e2eshark/onnx/models/gcresnext50ts.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gcresnext50ts.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/gcresnext50ts.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ghostnet_100/model.py
+++ b/e2eshark/onnx/models/ghostnet_100/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_inception_v3/model.py
+++ b/e2eshark/onnx/models/gluon_inception_v3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet101_v1b/model.py
+++ b/e2eshark/onnx/models/gluon_resnet101_v1b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet101_v1c/model.py
+++ b/e2eshark/onnx/models/gluon_resnet101_v1c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet101_v1d/model.py
+++ b/e2eshark/onnx/models/gluon_resnet101_v1d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet101_v1s/model.py
+++ b/e2eshark/onnx/models/gluon_resnet101_v1s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet152_v1b/model.py
+++ b/e2eshark/onnx/models/gluon_resnet152_v1b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet152_v1c/model.py
+++ b/e2eshark/onnx/models/gluon_resnet152_v1c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet152_v1d/model.py
+++ b/e2eshark/onnx/models/gluon_resnet152_v1d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet152_v1s/model.py
+++ b/e2eshark/onnx/models/gluon_resnet152_v1s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet18_v1b/model.py
+++ b/e2eshark/onnx/models/gluon_resnet18_v1b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet34_v1b/model.py
+++ b/e2eshark/onnx/models/gluon_resnet34_v1b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet50_v1b/model.py
+++ b/e2eshark/onnx/models/gluon_resnet50_v1b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet50_v1c/model.py
+++ b/e2eshark/onnx/models/gluon_resnet50_v1c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet50_v1d/model.py
+++ b/e2eshark/onnx/models/gluon_resnet50_v1d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnet50_v1s/model.py
+++ b/e2eshark/onnx/models/gluon_resnet50_v1s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnext101_32x4d/model.py
+++ b/e2eshark/onnx/models/gluon_resnext101_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnext101_64x4d/model.py
+++ b/e2eshark/onnx/models/gluon_resnext101_64x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_resnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/gluon_resnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_senet154/model.py
+++ b/e2eshark/onnx/models/gluon_senet154/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_seresnext101_32x4d/model.py
+++ b/e2eshark/onnx/models/gluon_seresnext101_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_seresnext101_64x4d/model.py
+++ b/e2eshark/onnx/models/gluon_seresnext101_64x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gluon_seresnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/gluon_seresnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_a/model.py
+++ b/e2eshark/onnx/models/hardcorenas_a/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_b/model.py
+++ b/e2eshark/onnx/models/hardcorenas_b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_c/model.py
+++ b/e2eshark/onnx/models/hardcorenas_c/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_d/model.py
+++ b/e2eshark/onnx/models/hardcorenas_d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_e/model.py
+++ b/e2eshark/onnx/models/hardcorenas_e/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hardcorenas_f/model.py
+++ b/e2eshark/onnx/models/hardcorenas_f/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w18/model.py
+++ b/e2eshark/onnx/models/hrnet_w18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w18_small/model.py
+++ b/e2eshark/onnx/models/hrnet_w18_small/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w18_small_v2/model.py
+++ b/e2eshark/onnx/models/hrnet_w18_small_v2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w30/model.py
+++ b/e2eshark/onnx/models/hrnet_w30/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w32/model.py
+++ b/e2eshark/onnx/models/hrnet_w32/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w40/model.py
+++ b/e2eshark/onnx/models/hrnet_w40/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w44/model.py
+++ b/e2eshark/onnx/models/hrnet_w44/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w48/model.py
+++ b/e2eshark/onnx/models/hrnet_w48/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/hrnet_w64/model.py
+++ b/e2eshark/onnx/models/hrnet_w64/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ig_resnext101_32x16d/model.py
+++ b/e2eshark/onnx/models/ig_resnext101_32x16d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ig_resnext101_32x32d/model.py
+++ b/e2eshark/onnx/models/ig_resnext101_32x32d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ig_resnext101_32x8d/model.py
+++ b/e2eshark/onnx/models/ig_resnext101_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_resnet_v2/model.py
+++ b/e2eshark/onnx/models/inception_resnet_v2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v3/model.py
+++ b/e2eshark/onnx/models/inception_v3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v4/model.py
+++ b/e2eshark/onnx/models/inception_v4/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_senet154/model.py
+++ b/e2eshark/onnx/models/legacy_senet154/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnet101/model.py
+++ b/e2eshark/onnx/models/legacy_seresnet101/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnet152/model.py
+++ b/e2eshark/onnx/models/legacy_seresnet152/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnet18/model.py
+++ b/e2eshark/onnx/models/legacy_seresnet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnet34/model.py
+++ b/e2eshark/onnx/models/legacy_seresnet34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnet50/model.py
+++ b/e2eshark/onnx/models/legacy_seresnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnext101_32x4d/model.py
+++ b/e2eshark/onnx/models/legacy_seresnext101_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnext26_32x4d/model.py
+++ b/e2eshark/onnx/models/legacy_seresnext26_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/legacy_seresnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/legacy_seresnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mixnet_l.ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixnet_l.ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mixnet_m.ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixnet_m.ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mixnet_s.ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixnet_s.ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mixnet_xl.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mixnet_xl.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.miil_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.miil_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_rw.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_rw.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nf_regnet_b1.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/nf_regnet_b1.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nf_regnet_b1.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/nf_regnet_b1.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nf_resnet50.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/nf_resnet50.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nf_resnet50.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/nf_resnet50.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nfnet_l0.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/nfnet_l0.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/nfnet_l0.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/nfnet_l0.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetv_040.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetv_040.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetv_040.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetv_040.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetv_064.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetv_064.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetv_064.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetv_064.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_002.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_002.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_004.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_004.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_004_tv.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_004_tv.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_006.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_006.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_008.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_008.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_008.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_008.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_016.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_016.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_016.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_016.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_032.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_032.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_032.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_032.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_040.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_040.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_064.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_064.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_080.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_080.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_080.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_080.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_120.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_120.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_160.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_160.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_160.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_160.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_320.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_320.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetx_320.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnetx_320.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_002.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_002.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_004.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_004.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_004.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_004.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_006.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_006.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_008.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_008.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_008_tv.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_008_tv.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_016.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_016.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_016.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_016.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_032.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_032.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_032.ra_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_032.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_032.ra_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_032.ra_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_032.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_032.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_040.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_040.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_040.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_040.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_040.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_040.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_064.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_064.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_064.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_064.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_064.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_064.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_080.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_080.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_080.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_080.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_080.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_080.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_080_tv.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_080_tv.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_120.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_120.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_120.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_120.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_120.sw_in12k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_120.sw_in12k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.lion_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.lion_in12k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.lion_in12k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_160.lion_in12k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.sw_in12k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnety_160.sw_in12k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.swag_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.swag_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.swag_lc_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.swag_lc_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_160.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_320.pycls_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_320.pycls_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_320.seer_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_320.seer_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_320.swag_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_320.swag_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_320.swag_lc_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_320.swag_lc_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_320.tv2_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_320.tv2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnety_640.seer_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_640.seer_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_040.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_040.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_040.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_040.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_040_h.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_040_h.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_040_h.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_040_h.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_b16.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_b16.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_b16.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_b16.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_c16.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_c16.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_c16.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_c16.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_c16_evos.ch_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_c16_evos.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_c16_evos.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_c16_evos.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d32.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_d32.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d32.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_d32.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d8.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_d8.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d8.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_d8.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d8_evos.ch_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_d8_evos.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_d8_evos.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_d8_evos.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_e8.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/regnetz_e8.ra3_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/regnetz_e8.ra3_in1k_train/model.py
+++ b/e2eshark/onnx/models/regnetz_e8.ra3_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_a2.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_a2.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b0.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b0.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b1.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b1.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b1g4.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b1g4.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b2.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b2.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b2g4.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b2g4.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b3.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b3.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/repvgg_b3g4.rvgg_in1k/model.py
+++ b/e2eshark/onnx/models/repvgg_b3g4.rvgg_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net101_26w_4s/model.py
+++ b/e2eshark/onnx/models/res2net101_26w_4s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net50_14w_8s/model.py
+++ b/e2eshark/onnx/models/res2net50_14w_8s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net50_26w_4s/model.py
+++ b/e2eshark/onnx/models/res2net50_26w_4s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net50_26w_6s/model.py
+++ b/e2eshark/onnx/models/res2net50_26w_6s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net50_26w_8s/model.py
+++ b/e2eshark/onnx/models/res2net50_26w_8s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2net50_48w_2s/model.py
+++ b/e2eshark/onnx/models/res2net50_48w_2s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/res2next50/model.py
+++ b/e2eshark/onnx/models/res2next50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_12_224.fb_distilled_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_12_224.fb_distilled_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_12_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_12_224.fb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_24_224.fb_distilled_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_24_224.fb_distilled_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_24_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_24_224.fb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_36_224.fb_distilled_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_36_224.fb_distilled_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_36_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_36_224.fb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resmlp_big_24_224.fb_distilled_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_big_24_224.fb_distilled_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest101e/model.py
+++ b/e2eshark/onnx/models/resnest101e/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest14d/model.py
+++ b/e2eshark/onnx/models/resnest14d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest26d/model.py
+++ b/e2eshark/onnx/models/resnest26d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest50d/model.py
+++ b/e2eshark/onnx/models/resnest50d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest50d_1s4x24d/model.py
+++ b/e2eshark/onnx/models/resnest50d_1s4x24d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnest50d_4s2x40d/model.py
+++ b/e2eshark/onnx/models/resnest50d_4s2x40d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet101/model.py
+++ b/e2eshark/onnx/models/resnet101/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet101_test/model.py
+++ b/e2eshark/onnx/models/resnet101_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet101d/model.py
+++ b/e2eshark/onnx/models/resnet101d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet101d_train/model.py
+++ b/e2eshark/onnx/models/resnet101d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet10t/model.py
+++ b/e2eshark/onnx/models/resnet10t/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet10t_train/model.py
+++ b/e2eshark/onnx/models/resnet10t_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet14t/model.py
+++ b/e2eshark/onnx/models/resnet14t/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet14t_train/model.py
+++ b/e2eshark/onnx/models/resnet14t_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet152/model.py
+++ b/e2eshark/onnx/models/resnet152/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet152_test/model.py
+++ b/e2eshark/onnx/models/resnet152_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet152d/model.py
+++ b/e2eshark/onnx/models/resnet152d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet152d_train/model.py
+++ b/e2eshark/onnx/models/resnet152d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet18/model.py
+++ b/e2eshark/onnx/models/resnet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet18_test/model.py
+++ b/e2eshark/onnx/models/resnet18_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet18d/model.py
+++ b/e2eshark/onnx/models/resnet18d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet18d_test/model.py
+++ b/e2eshark/onnx/models/resnet18d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet200d/model.py
+++ b/e2eshark/onnx/models/resnet200d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet200d_train/model.py
+++ b/e2eshark/onnx/models/resnet200d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26/model.py
+++ b/e2eshark/onnx/models/resnet26/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26_test/model.py
+++ b/e2eshark/onnx/models/resnet26_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26d/model.py
+++ b/e2eshark/onnx/models/resnet26d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26d_test/model.py
+++ b/e2eshark/onnx/models/resnet26d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26t/model.py
+++ b/e2eshark/onnx/models/resnet26t/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet26t_test/model.py
+++ b/e2eshark/onnx/models/resnet26t_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet34/model.py
+++ b/e2eshark/onnx/models/resnet34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet34_test/model.py
+++ b/e2eshark/onnx/models/resnet34_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet34d/model.py
+++ b/e2eshark/onnx/models/resnet34d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet34d_test/model.py
+++ b/e2eshark/onnx/models/resnet34d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50/model.py
+++ b/e2eshark/onnx/models/resnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50_gn/model.py
+++ b/e2eshark/onnx/models/resnet50_gn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50_gn_test/model.py
+++ b/e2eshark/onnx/models/resnet50_gn_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50_test/model.py
+++ b/e2eshark/onnx/models/resnet50_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50d/model.py
+++ b/e2eshark/onnx/models/resnet50d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50d_test/model.py
+++ b/e2eshark/onnx/models/resnet50d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet51q.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet51q.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet51q.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnet51q.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet61q.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet61q.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet61q.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnet61q.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetaa50/model.py
+++ b/e2eshark/onnx/models/resnetaa50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetaa50_train/model.py
+++ b/e2eshark/onnx/models/resnetaa50_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetblur50/model.py
+++ b/e2eshark/onnx/models/resnetblur50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetblur50_test/model.py
+++ b/e2eshark/onnx/models/resnetblur50_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs101/model.py
+++ b/e2eshark/onnx/models/resnetrs101/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs101_train/model.py
+++ b/e2eshark/onnx/models/resnetrs101_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs152/model.py
+++ b/e2eshark/onnx/models/resnetrs152/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs152_train/model.py
+++ b/e2eshark/onnx/models/resnetrs152_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs200/model.py
+++ b/e2eshark/onnx/models/resnetrs200/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs200_train/model.py
+++ b/e2eshark/onnx/models/resnetrs200_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs50/model.py
+++ b/e2eshark/onnx/models/resnetrs50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetrs50_train/model.py
+++ b/e2eshark/onnx/models/resnetrs50_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_101.a1h_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_101.a1h_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_101.a1h_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnetv2_101.a1h_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_101x1_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_101x1_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_152x2_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_152x2_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_152x2_bit.goog_teacher_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_152x2_bit.goog_teacher_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_152x2_bit.goog_teacher_in21k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/resnetv2_152x2_bit.goog_teacher_in21k_ft_in1k_384/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50.a1h_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50.a1h_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50.a1h_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnetv2_50.a1h_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50d_evos.ah_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50d_evos.ah_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50d_evos.ah_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnetv2_50d_evos.ah_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50d_gn.ah_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50d_gn.ah_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50d_gn.ah_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnetv2_50d_gn.ah_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50x1_bit.goog_distilled_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50x1_bit.goog_distilled_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50x1_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50x1_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnetv2_50x3_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_50x3_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext101_32x8d/model.py
+++ b/e2eshark/onnx/models/resnext101_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext101_64x4d/model.py
+++ b/e2eshark/onnx/models/resnext101_64x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext101_64x4d_train/model.py
+++ b/e2eshark/onnx/models/resnext101_64x4d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext26ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnext26ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext26ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/resnext26ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/resnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext50_32x4d_test/model.py
+++ b/e2eshark/onnx/models/resnext50_32x4d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext50d_32x4d/model.py
+++ b/e2eshark/onnx/models/resnext50d_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnext50d_32x4d_test/model.py
+++ b/e2eshark/onnx/models/resnext50d_32x4d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnet_100.nav_in1k/model.py
+++ b/e2eshark/onnx/models/rexnet_100.nav_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnet_130.nav_in1k/model.py
+++ b/e2eshark/onnx/models/rexnet_130.nav_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnet_150.nav_in1k/model.py
+++ b/e2eshark/onnx/models/rexnet_150.nav_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnet_200.nav_in1k/model.py
+++ b/e2eshark/onnx/models/rexnet_200.nav_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnet_300.nav_in1k/model.py
+++ b/e2eshark/onnx/models/rexnet_300.nav_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnetr_200.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/rexnetr_200.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnetr_200.sw_in12k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/rexnetr_200.sw_in12k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnetr_300.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/rexnetr_300.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/rexnetr_300.sw_in12k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/rexnetr_300.sw_in12k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/selecsls42b/model.py
+++ b/e2eshark/onnx/models/selecsls42b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/selecsls60/model.py
+++ b/e2eshark/onnx/models/selecsls60/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/selecsls60b/model.py
+++ b/e2eshark/onnx/models/selecsls60b/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/semnasnet_075.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/semnasnet_075.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/semnasnet_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/semnasnet_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/sequencer2d_m/model.py
+++ b/e2eshark/onnx/models/sequencer2d_m/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/sequencer2d_s/model.py
+++ b/e2eshark/onnx/models/sequencer2d_s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet152d/model.py
+++ b/e2eshark/onnx/models/seresnet152d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet152d_train/model.py
+++ b/e2eshark/onnx/models/seresnet152d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/seresnet33ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet33ts.ra2_in1k_train/model.py
+++ b/e2eshark/onnx/models/seresnet33ts.ra2_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet50/model.py
+++ b/e2eshark/onnx/models/seresnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnet50_test/model.py
+++ b/e2eshark/onnx/models/seresnet50_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext101_32x8d/model.py
+++ b/e2eshark/onnx/models/seresnext101_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext101_32x8d_train/model.py
+++ b/e2eshark/onnx/models/seresnext101_32x8d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext101d_32x8d/model.py
+++ b/e2eshark/onnx/models/seresnext101d_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext101d_32x8d_train/model.py
+++ b/e2eshark/onnx/models/seresnext101d_32x8d_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26d_32x4d/model.py
+++ b/e2eshark/onnx/models/seresnext26d_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26d_32x4d_test/model.py
+++ b/e2eshark/onnx/models/seresnext26d_32x4d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26t_32x4d/model.py
+++ b/e2eshark/onnx/models/seresnext26t_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26t_32x4d_test/model.py
+++ b/e2eshark/onnx/models/seresnext26t_32x4d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26ts.ch_in1k/model.py
+++ b/e2eshark/onnx/models/seresnext26ts.ch_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext26ts.ch_in1k_train/model.py
+++ b/e2eshark/onnx/models/seresnext26ts.ch_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/seresnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnext50_32x4d_test/model.py
+++ b/e2eshark/onnx/models/seresnext50_32x4d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnextaa101d_32x8d/model.py
+++ b/e2eshark/onnx/models/seresnextaa101d_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/seresnextaa101d_32x8d_test/model.py
+++ b/e2eshark/onnx/models/seresnextaa101d_32x8d_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/skresnet18/model.py
+++ b/e2eshark/onnx/models/skresnet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/skresnet34/model.py
+++ b/e2eshark/onnx/models/skresnet34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/skresnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/skresnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/spnasnet_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/spnasnet_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnet18/model.py
+++ b/e2eshark/onnx/models/ssl_resnet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnet50/model.py
+++ b/e2eshark/onnx/models/ssl_resnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnext101_32x16d/model.py
+++ b/e2eshark/onnx/models/ssl_resnext101_32x16d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnext101_32x4d/model.py
+++ b/e2eshark/onnx/models/ssl_resnext101_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnext101_32x8d/model.py
+++ b/e2eshark/onnx/models/ssl_resnext101_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ssl_resnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/ssl_resnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnet18/model.py
+++ b/e2eshark/onnx/models/swsl_resnet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnet50/model.py
+++ b/e2eshark/onnx/models/swsl_resnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnext101_32x16d/model.py
+++ b/e2eshark/onnx/models/swsl_resnext101_32x16d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnext101_32x4d/model.py
+++ b/e2eshark/onnx/models/swsl_resnext101_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnext101_32x8d/model.py
+++ b/e2eshark/onnx/models/swsl_resnext101_32x8d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/swsl_resnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/swsl_resnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_el.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_el.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_em.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_em.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_es.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_es.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_lite0.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_lite0.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_lite1.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_lite1.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_lite2.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_lite2.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_lite3.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_lite3.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnet_lite4.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_lite4.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b0.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b0.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b0.in1k_train/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b0.in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b1.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b1.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b1.in1k_train/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b1.in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b2.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b2.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b2.in1k_train/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b2.in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b3.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b3.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b3.in1k_train/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b3.in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b3.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b3.in21k_ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_efficientnetv2_b3.in21k_ft_in1k_train/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_b3.in21k_ft_in1k_train/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_inception_v3/model.py
+++ b/e2eshark/onnx/models/tf_inception_v3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_mobilenetv3_large_minimal_100.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_large_minimal_100.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_mobilenetv3_small_075.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_small_075.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_mobilenetv3_small_100.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_small_100.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tf_mobilenetv3_small_minimal_100.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_small_minimal_100.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tinynet_a.in1k/model.py
+++ b/e2eshark/onnx/models/tinynet_a.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tinynet_d.in1k/model.py
+++ b/e2eshark/onnx/models/tinynet_d.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_densenet121/model.py
+++ b/e2eshark/onnx/models/tv_densenet121/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_resnet101/model.py
+++ b/e2eshark/onnx/models/tv_resnet101/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_resnet152/model.py
+++ b/e2eshark/onnx/models/tv_resnet152/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_resnet34/model.py
+++ b/e2eshark/onnx/models/tv_resnet34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_resnet50/model.py
+++ b/e2eshark/onnx/models/tv_resnet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/tv_resnext50_32x4d/model.py
+++ b/e2eshark/onnx/models/tv_resnext50_32x4d/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg11/model.py
+++ b/e2eshark/onnx/models/vgg11/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg11_bn/model.py
+++ b/e2eshark/onnx/models/vgg11_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg13/model.py
+++ b/e2eshark/onnx/models/vgg13/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg13_bn/model.py
+++ b/e2eshark/onnx/models/vgg13_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg16/model.py
+++ b/e2eshark/onnx/models/vgg16/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg16_bn/model.py
+++ b/e2eshark/onnx/models/vgg16_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg19/model.py
+++ b/e2eshark/onnx/models/vgg19/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/vgg19_bn/model.py
+++ b/e2eshark/onnx/models/vgg19_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/wide_resnet101_2/model.py
+++ b/e2eshark/onnx/models/wide_resnet101_2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/wide_resnet50_2/model.py
+++ b/e2eshark/onnx/models/wide_resnet50_2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/wide_resnet50_2_test/model.py
+++ b/e2eshark/onnx/models/wide_resnet50_2_test/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception/model.py
+++ b/e2eshark/onnx/models/xception/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception41/model.py
+++ b/e2eshark/onnx/models/xception41/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception41p/model.py
+++ b/e2eshark/onnx/models/xception41p/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception65/model.py
+++ b/e2eshark/onnx/models/xception65/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception65p/model.py
+++ b/e2eshark/onnx/models/xception65p/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/xception71/model.py
+++ b/e2eshark/onnx/models/xception71/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]


### PR DESCRIPTION
Followed @kumardeepakamd  [instructions](https://github.com/nod-ai/playbook/blob/main/HOWTO/Setup/onnx-model-tests.md), these files are on xco server, automatically generated by `tools/aztestsetup.py`

`python tools/aztestsetup.py -s /proj/ai_models/cnn/ipu_models/int8/vai_q_onnx/ -m onnx/models/ResNet152_vaiq_int8/model.py -c huggingface_cache --setup --upload list`

`python tools/aztestsetup.py -s /proj/ai_models/cnn/ipu_models/fp32/opset17/ -m onnx/models/ResNet152_vaiq_int8/model.py -c huggingface_cache --setup --upload list1`

Those models have been upload into public onnxstorage.

Then the inputs for each models has to be manually created by this method:

> [SHARK-TestSuite/e2eshark/tools/stubs/commonutils.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/tools/stubs/commonutils.py#L91)
> , you will need to add parameters to specify input dimensions and then make this line
> [SHARK-TestSuite/e2eshark/tools/stubs/commonutils.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/tools/stubs/commonutils.py#L95)
> use the parameters. Then, in the model.py file, change this line to pass the appropriate input parameters based on the model
> [SHARK-TestSuite/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py#L25)

