### PR TITLE
Add 76 onnx vision model int8 & f32 model.py

### DIFF
--- a/e2eshark/onnx/models/DarkNet53/model.py
+++ b/e2eshark/onnx/models/DarkNet53/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/DarkNet53/model.py
+++ b/e2eshark/onnx/models/DarkNet53/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/DarkNet53_vaiq/model.py
+++ b/e2eshark/onnx/models/DarkNet53_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/DarkNet53_vaiq/model.py
+++ b/e2eshark/onnx/models/DarkNet53_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/DarkNet53_vaiq/model.py
+++ b/e2eshark/onnx/models/DarkNet53_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b0/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b0/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b0/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b0/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b0_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b0_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b0_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b0_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b1/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b1/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b1/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(240, 240)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b1_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(240, 240)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b2/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2/model.py
@@ -42,8 +42,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b2/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b2/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b2_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b3/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b3/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(300, 300)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b3/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3/model.py
@@ -42,8 +42,5 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
 
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(320, 320)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b3_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b4/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b4/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b4/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(380, 380)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(384, 384)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b4_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b5/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(456, 456)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b5/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b5/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(456, 456)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b5_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b6/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b6/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b6/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(528, 528)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b6_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(528, 528)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b7/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b7/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(600, 600)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b7/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(600, 600)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_b7_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_l/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(384, 384)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_l/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_l/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(480, 480)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_l_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_m/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(480, 480)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_m/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_m/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(480, 480)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_m_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_s/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(480, 480)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_s/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_s/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(384, 384)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
+++ b/e2eshark/onnx/models/EfficientNet_v2_s_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/GoogLeNet/model.py
+++ b/e2eshark/onnx/models/GoogLeNet/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/GoogLeNet/model.py
+++ b/e2eshark/onnx/models/GoogLeNet/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/GoogLeNet_vaiq/model.py
+++ b/e2eshark/onnx/models/GoogLeNet_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/GoogLeNet_vaiq/model.py
+++ b/e2eshark/onnx/models/GoogLeNet_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Inception_v3/model.py
+++ b/e2eshark/onnx/models/Inception_v3/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Inception_v3/model.py
+++ b/e2eshark/onnx/models/Inception_v3/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Inception_v3/model.py
+++ b/e2eshark/onnx/models/Inception_v3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Inception_v3_vaiq/model.py
+++ b/e2eshark/onnx/models/Inception_v3_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Inception_v3_vaiq/model.py
+++ b/e2eshark/onnx/models/Inception_v3_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Inception_v3_vaiq/model.py
+++ b/e2eshark/onnx/models/Inception_v3_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV2/model.py
+++ b/e2eshark/onnx/models/MobileNetV2/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV2/model.py
+++ b/e2eshark/onnx/models/MobileNetV2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV2_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV2_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV2_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV2_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV3_large/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_large/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV3_large/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_large/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV3_large_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_large_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV3_large_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_large_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV3_small/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_small/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV3_small/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_small/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/MobileNetV3_small_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_small_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/MobileNetV3_small_vaiq/model.py
+++ b/e2eshark/onnx/models/MobileNetV3_small_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/RRDB_ESRGAN/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/RRDB_ESRGAN/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_pro_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(250, 250)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/RRDB_ESRGAN_vaiq/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/RRDB_ESRGAN_vaiq/model.py
+++ b/e2eshark/onnx/models/RRDB_ESRGAN_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet101/model.py
+++ b/e2eshark/onnx/models/ResNet101/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet101/model.py
+++ b/e2eshark/onnx/models/ResNet101/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet101_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet101_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet101_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet101_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet152/model.py
+++ b/e2eshark/onnx/models/ResNet152/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet152/model.py
+++ b/e2eshark/onnx/models/ResNet152/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet152_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet152_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet152_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet152_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet18/model.py
+++ b/e2eshark/onnx/models/ResNet18/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet18/model.py
+++ b/e2eshark/onnx/models/ResNet18/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet18_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet18_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet18_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet18_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet34/model.py
+++ b/e2eshark/onnx/models/ResNet34/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet34/model.py
+++ b/e2eshark/onnx/models/ResNet34/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet34_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet34_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet34_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet34_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet50/model.py
+++ b/e2eshark/onnx/models/ResNet50/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet50/model.py
+++ b/e2eshark/onnx/models/ResNet50/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/ResNet50_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet50_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/ResNet50_vaiq/model.py
+++ b/e2eshark/onnx/models/ResNet50_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/SqueezeNet_1_0/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_0/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/SqueezeNet_1_0/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_0/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/SqueezeNet_1_0_vaiq/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_0_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/SqueezeNet_1_0_vaiq/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_0_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/SqueezeNet_1_1/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_1/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/SqueezeNet_1_1/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_1/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/SqueezeNet_1_1_vaiq/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_1_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/SqueezeNet_1_1_vaiq/model.py
+++ b/e2eshark/onnx/models/SqueezeNet_1_1_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG11/model.py
+++ b/e2eshark/onnx/models/VGG11/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG11/model.py
+++ b/e2eshark/onnx/models/VGG11/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG11_bn/model.py
+++ b/e2eshark/onnx/models/VGG11_bn/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG11_bn/model.py
+++ b/e2eshark/onnx/models/VGG11_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG11_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG11_bn_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG11_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG11_bn_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG11_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG11_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG11_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG11_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG13/model.py
+++ b/e2eshark/onnx/models/VGG13/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG13/model.py
+++ b/e2eshark/onnx/models/VGG13/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG13_bn/model.py
+++ b/e2eshark/onnx/models/VGG13_bn/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG13_bn/model.py
+++ b/e2eshark/onnx/models/VGG13_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG13_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG13_bn_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG13_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG13_bn_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG13_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG13_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG13_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG13_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG16/model.py
+++ b/e2eshark/onnx/models/VGG16/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG16/model.py
+++ b/e2eshark/onnx/models/VGG16/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG16_bn/model.py
+++ b/e2eshark/onnx/models/VGG16_bn/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG16_bn/model.py
+++ b/e2eshark/onnx/models/VGG16_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG16_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG16_bn_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG16_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG16_bn_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG16_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG16_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG16_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG16_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG19/model.py
+++ b/e2eshark/onnx/models/VGG19/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG19/model.py
+++ b/e2eshark/onnx/models/VGG19/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG19_bn/model.py
+++ b/e2eshark/onnx/models/VGG19_bn/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG19_bn/model.py
+++ b/e2eshark/onnx/models/VGG19_bn/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG19_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG19_bn_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG19_bn_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG19_bn_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/VGG19_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG19_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/VGG19_vaiq/model.py
+++ b/e2eshark/onnx/models/VGG19_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/WideResNet_101_2/model.py
+++ b/e2eshark/onnx/models/WideResNet_101_2/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/WideResNet_101_2/model.py
+++ b/e2eshark/onnx/models/WideResNet_101_2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/WideResNet_101_2_vaiq/model.py
+++ b/e2eshark/onnx/models/WideResNet_101_2_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/WideResNet_101_2_vaiq/model.py
+++ b/e2eshark/onnx/models/WideResNet_101_2_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/WideResNet_50_2/model.py
+++ b/e2eshark/onnx/models/WideResNet_50_2/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/WideResNet_50_2/model.py
+++ b/e2eshark/onnx/models/WideResNet_50_2/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/WideResNet_50_2_vaiq/model.py
+++ b/e2eshark/onnx/models/WideResNet_50_2_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/WideResNet_50_2_vaiq/model.py
+++ b/e2eshark/onnx/models/WideResNet_50_2_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/YoloNetV3/model.py
+++ b/e2eshark/onnx/models/YoloNetV3/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(416, 416)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/YoloNetV3/model.py
+++ b/e2eshark/onnx/models/YoloNetV3/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/YoloNetV3/model.py
+++ b/e2eshark/onnx/models/YoloNetV3/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
+++ b/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(416, 416)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
+++ b/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
+++ b/e2eshark/onnx/models/YoloNetV3_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Yolov8m/model.py
+++ b/e2eshark/onnx/models/Yolov8m/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(640, 640)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Yolov8m/model.py
+++ b/e2eshark/onnx/models/Yolov8m/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Yolov8m/model.py
+++ b/e2eshark/onnx/models/Yolov8m/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Yolov8m_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8m_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(640, 640)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Yolov8m_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8m_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Yolov8m_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8m_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Yolov8n/model.py
+++ b/e2eshark/onnx/models/Yolov8n/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(640, 640)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Yolov8n/model.py
+++ b/e2eshark/onnx/models/Yolov8n/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Yolov8n/model.py
+++ b/e2eshark/onnx/models/Yolov8n/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/Yolov8n_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8n_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(640, 640)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/Yolov8n_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8n_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/Yolov8n_vaiq/model.py
+++ b/e2eshark/onnx/models/Yolov8n_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla169/model.py
+++ b/e2eshark/onnx/models/dla169/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/dla169/model.py
+++ b/e2eshark/onnx/models/dla169/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/dla169_vaiq/model.py
+++ b/e2eshark/onnx/models/dla169_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/dla169_vaiq/model.py
+++ b/e2eshark/onnx/models/dla169_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b0.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b0.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b0.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b0.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b0.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b1.ft_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1.ft_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2.ra_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(256, 256)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(224, 224)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(320, 320)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b4.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b5.sw_in12k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.sw_in12k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b5.sw_in12k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.sw_in12k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(448, 448)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.sw_in12k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el.ra_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(300, 300)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_el_pruned.in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(300, 300)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_em.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(240, 240)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_es.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_es.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_es.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_es.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_es_pruned.in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_es_pruned.in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_es_pruned.in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_es_pruned.in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_es_pruned.in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_lite0.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnet_lite0.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_lite0.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnet_lite0.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnet_lite0.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(320, 320)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_m.agc_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_s.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/efficientnetv2_rw_t.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(288, 288)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/fbnetc_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/fbnetc_100.rmsp_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/fbnetc_100.rmsp_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/fbnetc_100.rmsp_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/fbnetc_100.rmsp_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_l.idstcv_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(256, 256)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_m.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_m.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_m.idstcv_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_m.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_m.idstcv_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
+++ b/e2eshark/onnx/models/gernet_s.idstcv_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/gernet_s.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_s.idstcv_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/gernet_s.idstcv_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/gernet_s.idstcv_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v3.tf_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(299, 299)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/inception_v4.tf_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_050.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_050.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_050.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_050.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_050.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_075.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_075.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_075.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_075.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_075.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/lcnet_100.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/lcnet_100.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_100.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/lcnet_100.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/lcnet_100.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_100.rmsp_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_100.rmsp_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mnasnet_100.rmsp_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mnasnet_100.rmsp_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mnasnet_100.rmsp_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mnasnet_small.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mnasnet_small.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mnasnet_small.lamb_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mnasnet_small.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mnasnet_small.lamb_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_050.lamb_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_100.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_100.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_100.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_100.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_100.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_110d.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_120d.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_140.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv2_140.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_140.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv2_140.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv2_140.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_large_100.ra_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_050.lamb_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_075.lamb_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/mobilenetv3_small_100.lamb_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet32ts.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(256, 256)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet33ts.ra2_in1k_vaiq/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(256, 256)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/resnet50.a1_in1k/model.py
+++ b/e2eshark/onnx/models/resnet50.a1_in1k/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet50.a1_in1k/model.py
+++ b/e2eshark/onnx/models/resnet50.a1_in1k/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/resnet50.a1_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet50.a1_in1k_vaiq/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/resnet50.a1_in1k_vaiq/model.py
+++ b/e2eshark/onnx/models/resnet50.a1_in1k_vaiq/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/onnx/models/yolov3-original/model.py
+++ b/e2eshark/onnx/models/yolov3-original/model.py
@@ -22,7 +22,7 @@ session = onnxruntime.InferenceSession("model.onnx", None)
 # Even if model is quantized, the inputs and outputs are
 # not, so apply float32
 # Get and process the image
-img_ycbcr = setup_test_image()
+img_ycbcr = setup_test_image(416, 416)
 
 model_input_X = to_numpy(img_ycbcr)
 

--- a/e2eshark/onnx/models/yolov3-original/model.py
+++ b/e2eshark/onnx/models/yolov3-original/model.py
@@ -41,9 +41,3 @@ E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
 
 print("Input:", E2ESHARK_CHECK["input"])
 print("Output:", E2ESHARK_CHECK["output"])
-
-# Post process output to do:
-E2ESHARK_CHECK["postprocess"] = [
-    (torch.nn.functional.softmax, [0], False, 0),
-    (torch.topk, [1], True, 1),
-]

--- a/e2eshark/onnx/models/yolov3-original/model.py
+++ b/e2eshark/onnx/models/yolov3-original/model.py
@@ -1,0 +1,49 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])
+
+# Post process output to do:
+E2ESHARK_CHECK["postprocess"] = [
+    (torch.nn.functional.softmax, [0], False, 0),
+    (torch.topk, [1], True, 1),
+]

--- a/e2eshark/tools/stubs/commonutils.py
+++ b/e2eshark/tools/stubs/commonutils.py
@@ -88,11 +88,11 @@ def postProcess(e2esharkDict):
 def to_numpy(tensor):
     return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
 
-def setup_test_image():
+def setup_test_image(height=224, weight=224):
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     img = Image.open(requests.get(url, stream=True).raw)
 
-    resize = transforms.Resize([224, 224])
+    resize = transforms.Resize([height, weight])
     img = resize(img)
     
     # Define a transform to convert 


### PR DESCRIPTION
 All models has been uploaded to XSJ server.
These files are automatically generated by aztestsetup.py. Next step is to change the input for them one by one.

[SHARK-TestSuite/e2eshark/tools/stubs/commonutils.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/tools/stubs/commonutils.py#L91)
, you will need to add parameters to specify input dimensions and then make this line
[SHARK-TestSuite/e2eshark/tools/stubs/commonutils.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/tools/stubs/commonutils.py#L95)
use the parameters. Then, in the model.py file, change this line to pass the appropriate input parameters based on the model
[SHARK-TestSuite/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py at main · nod-ai/SHARK-TestSuite (github.com)](https://github.com/nod-ai/SHARK-TestSuite/blob/main/e2eshark/onnx/models/AlexNet_vaiq_int8/model.py#L25)