### PR TITLE
Revert "Fix download address for onnx models (#290)"

### DIFF
--- a/e2eshark/tools/aztestsetup.py
+++ b/e2eshark/tools/aztestsetup.py
@@ -84,7 +84,7 @@ def download_and_setup_onnxmodels(cache_dir, testList):
     priv_container_name = "onnxprivatestorage"
 
     for model in testList:
-        blob_dir =  "e2eshark/onnx/models/" + model
+        blob_dir =  "e2eshark/" + model
         blob_name = blob_dir + "/model.onnx.zip"
         dest_file = cache_dir + "/" + blob_name
         if os.path.exists(dest_file):


### PR DESCRIPTION
This reverts commit f6341055bfc4e2cd0db406db0903f6a28fa2fa8a.

https://github.com/nod-ai/SHARK-TestSuite/pull/290

Then the upload/download/run can provide list like this style: 

Upload a list of onnx model:
`python tools/aztestsetup.py -s /proj/ai_models/cnn/ipu_models/int8/vai_q_onnx// -m onnx/models/ResNet152_vaiq_int8/model.py -c huggingface_cache --setup --upload list_upload.txt`

**list_upload.txt** :
```
DarkNet53_vaiq
dla169_vaiq
```

Download a list of onnx model:
`
YOUR_AZ_KEY python tools/aztestsetup.py --cachedir  /proj/gdba/shark/cache --download listrun.txt 
`

**listrun.txt** :
```
onnx/models/DarkNet53_vaiq
onnx/models/dla169_vaiq
```

Run a list of onnx models: 
`python ./run.py  --tolerance 0.001 0.001 --cachedir /proj/gdba/shark/cache -f onnx -g models --mode onnx --report -j 24 --testsfile listrun.txt `

**listrun.txt** :
```
onnx/models/DarkNet53_vaiq
onnx/models/dla169_vaiq
```