### PR TITLE
[alt] Adds option for saving processed outputs and a deeplab example

### DIFF
--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -62,6 +62,9 @@ class OnnxModelInfo:
     def apply_postprocessing(self, output: TestTensors):
         """can be overridden to define post-processing methods for individual models"""
         return output
+    
+    def save_processed_output(self, output: TestTensors, save_to: str, name: str):
+        """can be overridden to provide instructions on saving processed outputs (e.g., images, labels, text)"""
 
     # the following helper methods aren't meant to be overriden
 

--- a/alt_e2eshark/onnx_tests/models/deeplab.py
+++ b/alt_e2eshark/onnx_tests/models/deeplab.py
@@ -1,0 +1,79 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import numpy
+import torch
+import urllib
+from PIL import Image
+from torchvision import transforms
+from e2e_testing.registry import register_test
+from e2e_testing.storage import TestTensors
+from .azure_models import AzureDownloadableModel
+
+label_map = numpy.array([
+    (0, 0, 0),  # background
+    (128, 0, 0),  # aeroplane
+    (0, 128, 0),  # bicycle
+    (128, 128, 0),  # bird
+    (0, 0, 128),  # boat
+    (128, 0, 128),  # bottle
+    (0, 128, 128),  # bus
+    (128, 128, 128),  # car
+    (64, 0, 0),  # cat
+    (192, 0, 0),  # chair
+    (64, 128, 0),  # cow
+    (192, 128, 0),  # dining table
+    (64, 0, 128),  # dog
+    (192, 0, 128),  # horse
+    (64, 128, 128),  # motorbike
+    (192, 128, 128),  # person
+    (0, 64, 0),  # potted plant
+    (128, 64, 0),  # sheep
+    (0, 192, 0),  # sofa
+    (128, 192, 0),  # train
+    (0, 64, 128),  # tv/monitor
+])
+
+class DeeplabModel(AzureDownloadableModel):
+    def construct_inputs(self):
+        log_dir = self.model.rstrip("model.onnx")
+        url, filename = ("https://github.com/pytorch/hub/raw/master/images/deeplab1.png", log_dir + "input.png")
+        try: urllib.URLopener().retrieve(url, filename)
+        except: urllib.request.urlretrieve(url, filename)
+        input_image = Image.open(filename)
+        input_image = input_image.convert("RGB")
+        self.img_size = input_image.size
+        preprocess = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            transforms.Resize((513,513)),
+        ])
+        input_tensor = preprocess(input_image)
+        input_batch = input_tensor.unsqueeze(0).transpose(1,2).transpose(2,3)
+        return TestTensors((input_batch,))
+
+    def apply_postprocessing(self, output: TestTensors):
+        processed_outputs = []
+        for d in output.to_torch().data:
+            c = torch.topk(torch.nn.functional.softmax(d, -1), 2)[-1][0,:,:,-1]
+            image = numpy.zeros([513,513,3]).astype(numpy.uint8)
+            for i in range(513):
+                for j in range(513):
+                    for k in range(3):
+                        image[i,j,k] = label_map[c[i,j]][k]
+            processed_outputs.append(image)
+        return TestTensors(processed_outputs)
+    
+    def save_processed_output(self, output: TestTensors, save_to: str, name: str):
+        c = 0
+        for d in output.to_numpy().data:
+            im = Image.fromarray(d)
+            if self.img_size:
+                im = im.resize(self.img_size)
+            fp = save_to + name + "." + str(c) + ".jpeg"
+            im.save(fp)
+            c += 1
+
+register_test(DeeplabModel, "deeplabv3")

--- a/alt_e2eshark/onnx_tests/models/model.py
+++ b/alt_e2eshark/onnx_tests/models/model.py
@@ -7,3 +7,4 @@
 from .azure_models import *
 from .opt_models import *
 from .vision_models import *
+from .deeplab import *

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -188,6 +188,9 @@ def run_tests(
             if curr_stage in stages:
                 golden_outputs = inst.apply_postprocessing(golden_outputs_raw)
                 outputs = inst.apply_postprocessing(outputs_raw)
+                inst.save_processed_output(golden_outputs, log_dir, "golden_output")
+                inst.save_processed_output(outputs, log_dir, "output")
+
         except Exception as e:
             log_exception(e, log_dir, curr_stage, t.unique_name, verbose)
             continue


### PR DESCRIPTION
Running this deeplab example will download an example image, load and transform it, run it through the test, then save the gold_output and output images. 

Unfortunately this is a private model example. I'll look and see if we have a public deeplab model to use as another example.