### PR TITLE
[alt] Add class decorator registration and more Conv examples

### DIFF
--- a/alt_e2eshark/e2e_testing/registry.py
+++ b/alt_e2eshark/e2e_testing/registry.py
@@ -11,6 +11,7 @@ _SEEN_NAMES = set()
 
 
 def register_test(test_class: type, test_name: str):
+    '''After defining a ModelInfo class "MyModelInfo", you can register it as a test with register_test(MyModelInfo, "my_test_name")'''
     # Ensure that there are no duplicate names in the global test registry.
     if test_name in _SEEN_NAMES:
         raise ValueError(
@@ -25,3 +26,8 @@ def register_test(test_class: type, test_name: str):
             model_constructor=test_class,
         )
     )
+
+# a class decorator alternative to register_test for convenience
+def register_with_name(name):
+    '''Use @register_with_name("my_test_name") before defining a ModelInfo class to add that ModelInfo as a test.'''
+    return lambda test_class : register_test(test_class, name)

--- a/alt_e2eshark/onnx_tests/combinations/multi_conv.py
+++ b/alt_e2eshark/onnx_tests/combinations/multi_conv.py
@@ -19,10 +19,10 @@ from e2e_testing.registry import register_test
 
 
 class MultipleConvBase(OnnxModelInfo):
-    def __init__(self, n, omp, cd, ov=None, use_bias=False, use_clips=False):
+    def __init__(self, use_bias, use_clips, *args, **kwargs):
         self.use_bias = use_bias
         self.use_clips = use_clips
-        super().__init__(n, omp, cd, ov)
+        super().__init__(*args, **kwargs)
 
     def construct_model(self):
         # float input tensor:
@@ -175,9 +175,9 @@ class MultipleConvBase(OnnxModelInfo):
         app_node("DequantizeLinear", ["BX0", "BS1", "ZP"], ["X0"])
         app_node("DequantizeLinear", ["BK0", "BS0", "ZP"], ["K0"])
         app_node(
-            op_type="Conv",
-            inputs=["X0", "K0", "B0"] if self.use_bias else ["X0", "K0"],
-            outputs=["AX1"],
+            "Conv",
+            ["X0", "K0", "B0"] if self.use_bias else ["X0", "K0"],
+            ["AX1"],
             group=1,
             kernel_shape=[3, 3],
             pads=[1, 1, 1, 1],
@@ -191,9 +191,9 @@ class MultipleConvBase(OnnxModelInfo):
         app_node("DequantizeLinear", ["BX1", "BS1", "ZP"], ["X1"])
         app_node("DequantizeLinear", ["BK1", "KS1", "ZP"], ["K1"])
         app_node(
-            op_type="Conv",
-            inputs=["X1", "K1", "B1"] if self.use_bias else ["X1", "K1"],
-            outputs=["AX2"],
+            "Conv",
+            ["X1", "K1", "B1"] if self.use_bias else ["X1", "K1"],
+            ["AX2"],
             group=32,
             kernel_shape=[3, 3],
             pads=[1, 1, 1, 1],
@@ -207,9 +207,9 @@ class MultipleConvBase(OnnxModelInfo):
         app_node("DequantizeLinear", ["BX2", "BS1", "ZP"], ["X2"])
         app_node("DequantizeLinear", ["BK2", "BS1", "ZP"], ["K2"])
         app_node(
-            op_type="Conv",
-            inputs=["X2", "K2", "B2"] if self.use_bias else ["X2", "K2"],
-            outputs=["X3"],
+            "Conv",
+            ["X2", "K2", "B2"] if self.use_bias else ["X2", "K2"],
+            ["X3"],
             group=1,
             kernel_shape=[1, 1],
             pads=[0, 0, 0, 0],
@@ -230,23 +230,23 @@ class MultipleConvBase(OnnxModelInfo):
 
 
 class MultipleConvModel(MultipleConvBase):
-    def __init__(self, n, omp, cd, ov=None):
-        super().__init__(n, omp, cd, ov, False, False)
+    def __init__(self, *args, **kwargs):
+        super().__init__(False, False, *args, **kwargs)
 
 
 class MultipleConvModelBias(MultipleConvBase):
-    def __init__(self, n, omp, cd, ov=None):
-        super().__init__(n, omp, cd, ov, True, False)
+    def __init__(self, *args, **kwargs):
+        super().__init__(True, False, *args, **kwargs)
 
 
 class MultipleConvModelBiasClips(MultipleConvBase):
-    def __init__(self, n, omp, cd, ov=None):
-        super().__init__(n, omp, cd, ov, True, True)
+    def __init__(self, *args, **kwargs):
+        super().__init__(True, True, *args, **kwargs)
 
 
 class MultipleConvModelClips(MultipleConvBase):
-    def __init__(self, n, omp, cd, ov=None):
-        super().__init__(n, omp, cd, ov, False, True)
+    def __init__(self, *args, **kwargs):
+        super().__init__(False, True, *args, **kwargs)
 
 
 register_test(MultipleConvModel, "multi_conv")

--- a/alt_e2eshark/onnx_tests/operators/conv.py
+++ b/alt_e2eshark/onnx_tests/operators/conv.py
@@ -1,0 +1,110 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from onnx import TensorProto
+import onnx
+from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_tensor
+
+from e2e_testing.framework import OnnxModelInfo
+from e2e_testing.registry import register_with_name
+
+class QConvModelBase(OnnxModelInfo):
+    def __init__(self, specs, *args, **kwargs):
+        (self.N, self.Cin, self.Hin, self.Win, self.Cout, self.groups, self.Hker, self.Wker, self.pads, self.dilations, self.strides) = specs
+        self.Hout = int((self.Hin + self.pads[0] + self.pads[2] - self.dilations[0]*(self.Hker - 1) - 1)/self.strides[0] + 1)
+        self.Wout = int((self.Win + self.pads[1] + self.pads[3] - self.dilations[1]*(self.Wker - 1) - 1)/self.strides[1] + 1)
+        super().__init__(*args, **kwargs)
+
+    def construct_model(self):
+        # float input tensor:
+        AX0 = make_tensor_value_info("AX0", TensorProto.FLOAT, [self.N, self.Cin, self.Hin, self.Win])
+        # quantized weight tensor inputs
+        BK = make_tensor_value_info("BK", TensorProto.INT8, [self.Cout, int(self.Cin/self.groups), self.Hker, self.Wker])
+        # output tensor
+        X1 = make_tensor_value_info("X1", TensorProto.FLOAT, [self.N, self.Cout, self.Hout, self.Wout])
+        
+        KZPT = make_tensor("ZPT", TensorProto.INT8, [], [0])
+        KST = make_tensor("KST", TensorProto.FLOAT, [], [3.125000e-02])
+        
+        node_list = []
+        app_node = lambda op_ty, inputs, outputs, **kwargs: node_list.append(
+            make_node(op_ty, inputs, outputs, **kwargs)
+        )
+        # Quantization Scheme Constants
+        app_node("Constant", [], ["KZP"], value=KZPT)
+        app_node("Constant", [], ["KS"], value=KST)
+        app_node("DynamicQuantizeLinear", ["AX0"], ["BX0", "X0S", "X0ZP"])
+        app_node("DequantizeLinear", ["BX0", "X0S", "X0ZP"], ["X0"])
+        app_node("DequantizeLinear", ["BK", "KS", "KZP"], ["K"])
+        app_node("Conv", ["X0", "K"], ["X1"],
+            group=self.groups,
+            kernel_shape=[self.Hker, self.Wker],
+            pads=self.pads,
+            strides=self.strides,
+        )
+
+        graph = make_graph(
+            node_list,
+            "main",
+            [AX0, BK],
+            [X1],
+        )
+
+        onnx_model = make_model(graph)
+        onnx_model.opset_import[0].version = 19
+
+        onnx.save(onnx_model, self.model)
+
+N = 2
+Cin = 3
+Hin = 12
+Win = 12
+Cout = 3
+groups = Cin
+Hker = 5
+Wker = 3
+pads = [2, 0, 2, 0]
+dilations = [1, 1]
+strides = [1, 1]
+
+get_specs = lambda : (N, Cin, Hin, Win, Cout, groups, Hker, Wker, pads, dilations, strides)
+
+depthwise_specs = get_specs()
+
+groups = 1
+pads = [0, 0, 0, 0]
+
+basic_specs = get_specs()
+
+pads = [1,0,2,1]
+
+asymmetric_pad_specs = get_specs()
+
+Cin = 6
+Cout = 9
+groups = 3
+pads = [0, 0, 0, 0]
+
+grouped_specs = get_specs() 
+
+@register_with_name("qconv_depthwise")
+class QConvDepthwise(QConvModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(depthwise_specs, *args, **kwargs)
+
+@register_with_name("qconv_basic")
+class QConvBasic(QConvModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(basic_specs, *args, **kwargs)
+
+@register_with_name("qconv_asymmetric_pads")
+class QConvAsymmetricPads(QConvModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(asymmetric_pad_specs, *args, **kwargs)
+
+@register_with_name("qconv_grouped")
+class QConvGrouped(QConvModelBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(grouped_specs, *args, **kwargs)

--- a/alt_e2eshark/onnx_tests/operators/model.py
+++ b/alt_e2eshark/onnx_tests/operators/model.py
@@ -9,3 +9,4 @@ from .concat import *
 from .dynamic_quantize_linear import *
 from .pad import *
 from .resize import *
+from .conv import *


### PR DESCRIPTION
Also fixes an issue with my last commit. I didn't notice the issue since re-running tests doesn't generate a new model.onnx unless you delete the old one or make a new rundirectory. It might be good to rework this so that operator/combination tests automatically regenerate the model each time. 