### PR TITLE
[ONNX] Add HF CNN fp32 model tests

### DIFF
--- a/e2eshark/onnx/models/bat_resnext26ts.ch_in1k/model.py
+++ b/e2eshark/onnx/models/bat_resnext26ts.ch_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beit_base_patch16_224.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beit_base_patch16_224.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beit_base_patch16_384.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beit_base_patch16_384.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beit_large_patch16_224.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beit_large_patch16_224.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beit_large_patch16_384.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beit_large_patch16_384.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beit_large_patch16_512.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beit_large_patch16_512.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beitv2_base_patch16_224.in1k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beitv2_base_patch16_224.in1k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/beitv2_large_patch16_224.in1k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/beitv2_large_patch16_224.in1k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/botnet26t_256/model.py
+++ b/e2eshark/onnx/models/botnet26t_256/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_m36_384/model.py
+++ b/e2eshark/onnx/models/cait_m36_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_m48_448/model.py
+++ b/e2eshark/onnx/models/cait_m48_448/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(448, 448)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_s24_224/model.py
+++ b/e2eshark/onnx/models/cait_s24_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_s24_384/model.py
+++ b/e2eshark/onnx/models/cait_s24_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_s36_384/model.py
+++ b/e2eshark/onnx/models/cait_s36_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_xs24_384/model.py
+++ b/e2eshark/onnx/models/cait_xs24_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_xxs24_224/model.py
+++ b/e2eshark/onnx/models/cait_xxs24_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_xxs24_384/model.py
+++ b/e2eshark/onnx/models/cait_xxs24_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_xxs36_224/model.py
+++ b/e2eshark/onnx/models/cait_xxs36_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/cait_xxs36_384/model.py
+++ b/e2eshark/onnx/models/cait_xxs36_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coat_lite_mini/model.py
+++ b/e2eshark/onnx/models/coat_lite_mini/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coat_lite_small/model.py
+++ b/e2eshark/onnx/models/coat_lite_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coat_lite_tiny/model.py
+++ b/e2eshark/onnx/models/coat_lite_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coat_mini/model.py
+++ b/e2eshark/onnx/models/coat_mini/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coat_tiny/model.py
+++ b/e2eshark/onnx/models/coat_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_0_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_0_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_1_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_1_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_2_rw_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/coatnet_2_rw_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_2_rw_224.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_2_rw_224.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_3_rw_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/coatnet_3_rw_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_bn_0_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_bn_0_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_nano_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_nano_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_1_rw2_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_1_rw2_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_1_rw2_224.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_1_rw2_224.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_1_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_1_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_2_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_2_rw_384.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_2_rw_384.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnet_rmlp_nano_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnet_rmlp_nano_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/coatnext_nano_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/coatnext_nano_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convit_base/model.py
+++ b/e2eshark/onnx/models/convit_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convit_small/model.py
+++ b/e2eshark/onnx/models/convit_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convit_tiny/model.py
+++ b/e2eshark/onnx/models/convit_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_atto.d2_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_atto.d2_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_atto_ols.a2_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_atto_ols.a2_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laion2b/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laion2b_augreg/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laion2b_augreg/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laion2b_augreg_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laion2b_augreg_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laiona/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laiona/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laiona_320/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laiona_320/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laiona_augreg_320/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laiona_augreg_320/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.clip_laiona_augreg_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_base.clip_laiona_augreg_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.fb_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_base.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_base.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_base.fb_in22k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_base.fb_in22k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_femto.d1_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_femto.d1_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_femto_ols.d1_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_femto_ols.d1_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large.fb_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_large.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_large.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large.fb_in22k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_large.fb_in22k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg/model.py
+++ b/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_augreg_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_ft_320/model.py
+++ b/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_ft_320/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_ft_soup_320/model.py
+++ b/e2eshark/onnx/models/convnext_large_mlp.clip_laion2b_ft_soup_320/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_nano.d1h_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_nano.d1h_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_nano.in12k/model.py
+++ b/e2eshark/onnx/models/convnext_nano.in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_nano.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_nano.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_nano_ols.d1h_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_nano_ols.d1h_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_pico.d1_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_pico.d1_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_pico_ols.d1_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_pico_ols.d1_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.fb_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_small.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_small.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.fb_in22k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_small.fb_in22k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.in12k/model.py
+++ b/e2eshark/onnx/models/convnext_small.in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_small.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_small.in12k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_small.in12k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.fb_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.fb_in22k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.fb_in22k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.in12k/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny.in12k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_tiny.in12k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_tiny_hnf.a2h_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_tiny_hnf.a2h_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_xlarge.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnext_xlarge.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_xlarge.fb_in22k_ft_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnext_xlarge.fb_in22k_ft_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_xxlarge.clip_laion2b_rewind/model.py
+++ b/e2eshark/onnx/models/convnext_xxlarge.clip_laion2b_rewind/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnext_xxlarge.clip_laion2b_soup/model.py
+++ b/e2eshark/onnx/models/convnext_xxlarge.clip_laion2b_soup/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_atto.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_atto.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_atto.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_atto.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_base.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_base.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in22k_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnextv2_base.fcmae_ft_in22k_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_femto.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_femto.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_femto.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_femto.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_huge.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_huge.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in22k_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in22k_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in22k_in1k_512/model.py
+++ b/e2eshark/onnx/models/convnextv2_huge.fcmae_ft_in22k_in1k_512/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_large.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_large.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in22k_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnextv2_large.fcmae_ft_in22k_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_nano.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_nano.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in22k_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnextv2_nano.fcmae_ft_in22k_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_pico.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_pico.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_pico.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_pico.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_tiny.fcmae/model.py
+++ b/e2eshark/onnx/models/convnextv2_tiny.fcmae/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in22k_in1k_384/model.py
+++ b/e2eshark/onnx/models/convnextv2_tiny.fcmae_ft_in22k_in1k_384/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_15_240/model.py
+++ b/e2eshark/onnx/models/crossvit_15_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_15_dagger_240/model.py
+++ b/e2eshark/onnx/models/crossvit_15_dagger_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_15_dagger_408/model.py
+++ b/e2eshark/onnx/models/crossvit_15_dagger_408/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(408, 408)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_18_240/model.py
+++ b/e2eshark/onnx/models/crossvit_18_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_18_dagger_240/model.py
+++ b/e2eshark/onnx/models/crossvit_18_dagger_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_18_dagger_408/model.py
+++ b/e2eshark/onnx/models/crossvit_18_dagger_408/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(408, 408)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_9_240/model.py
+++ b/e2eshark/onnx/models/crossvit_9_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_9_dagger_240/model.py
+++ b/e2eshark/onnx/models/crossvit_9_dagger_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_base_240/model.py
+++ b/e2eshark/onnx/models/crossvit_base_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_small_240/model.py
+++ b/e2eshark/onnx/models/crossvit_small_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/crossvit_tiny_240/model.py
+++ b/e2eshark/onnx/models/crossvit_tiny_240/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/darknet53/model.py
+++ b/e2eshark/onnx/models/darknet53/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/darknetaa53/model.py
+++ b/e2eshark/onnx/models/darknetaa53/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/davit_base.msft_in1k/model.py
+++ b/e2eshark/onnx/models/davit_base.msft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/davit_small.msft_in1k/model.py
+++ b/e2eshark/onnx/models/davit_small.msft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/davit_tiny.msft_in1k/model.py
+++ b/e2eshark/onnx/models/davit_tiny.msft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_base_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_base_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_base_patch16_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_base_patch16_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_base_patch16_384.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_base_patch16_384.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_base_patch16_384.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_base_patch16_384.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_huge_patch14_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_huge_patch14_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_huge_patch14_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_huge_patch14_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_large_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_large_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_large_patch16_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_large_patch16_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_large_patch16_384.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_large_patch16_384.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_large_patch16_384.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_large_patch16_384.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_medium_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_medium_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_medium_patch16_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_medium_patch16_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_small_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_small_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_small_patch16_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_small_patch16_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_small_patch16_384.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_small_patch16_384.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit3_small_patch16_384.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/deit3_small_patch16_384.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_base_distilled_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_base_distilled_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_base_distilled_patch16_384.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_base_distilled_patch16_384.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_base_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_base_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_base_patch16_384.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_base_patch16_384.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_small_distilled_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_small_distilled_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_small_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_small_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_tiny_distilled_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_tiny_distilled_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/deit_tiny_patch16_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/deit_tiny_patch16_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/densenet201/model.py
+++ b/e2eshark/onnx/models/densenet201/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/dm_nfnet_f2.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f2.dm_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(352, 352)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/dm_nfnet_f3.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f3.dm_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(416, 416)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/dm_nfnet_f4.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f4.dm_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/dm_nfnet_f5.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f5.dm_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/dm_nfnet_f6.dm_in1k/model.py
+++ b/e2eshark/onnx/models/dm_nfnet_f6.dm_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eca_botnext26ts_256/model.py
+++ b/e2eshark/onnx/models/eca_botnext26ts_256/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/ecaresnet269d/model.py
+++ b/e2eshark/onnx/models/ecaresnet269d/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(352, 352)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/edgenext_base/model.py
+++ b/e2eshark/onnx/models/edgenext_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/edgenext_small/model.py
+++ b/e2eshark/onnx/models/edgenext_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/edgenext_small_rw/model.py
+++ b/e2eshark/onnx/models/edgenext_small_rw/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/edgenext_x_small/model.py
+++ b/e2eshark/onnx/models/edgenext_x_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/edgenext_xx_small/model.py
+++ b/e2eshark/onnx/models/edgenext_xx_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformer_l1.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformer_l1.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformer_l3.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformer_l3.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformer_l7.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformer_l7.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformerv2_l.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformerv2_l.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformerv2_s0.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformerv2_s0.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformerv2_s1.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformerv2_s1.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientformerv2_s2.snap_dist_in1k/model.py
+++ b/e2eshark/onnx/models/efficientformerv2_s2.snap_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientnet_b1_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b1_pruned.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientnet_b2_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b2_pruned.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(260, 260)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientnet_b3_pruned.in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b3_pruned.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(300, 300)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientnet_b5.in12k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(416, 416)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/efficientnet_b5.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/efficientnet_b5.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(448, 448)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_giant_patch14_224.clip_ft_in1k/model.py
+++ b/e2eshark/onnx/models/eva_giant_patch14_224.clip_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_giant_patch14_336.clip_ft_in1k/model.py
+++ b/e2eshark/onnx/models/eva_giant_patch14_336.clip_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_giant_patch14_336.m30m_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/eva_giant_patch14_336.m30m_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_giant_patch14_560.m30m_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/eva_giant_patch14_560.m30m_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_large_patch14_196.in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/eva_large_patch14_196.in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(196, 196)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_large_patch14_196.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/eva_large_patch14_196.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(196, 196)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_large_patch14_336.in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/eva_large_patch14_336.in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(336, 336)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/eva_large_patch14_336.in22k_ft_in22k_in1k/model.py
+++ b/e2eshark/onnx/models/eva_large_patch14_336.in22k_ft_in22k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(336, 336)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_base.1200ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_base.1200ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_base.300ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_base.300ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_base.600ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_base.600ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_large.1200ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_large.1200ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_large.300ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_large.300ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_large.600ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_large.600ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_small.1200ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_small.1200ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_small.300ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_small.300ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/flexivit_small.600ep_in1k/model.py
+++ b/e2eshark/onnx/models/flexivit_small.600ep_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_base_lrf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_base_lrf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_base_srf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_base_srf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_small_lrf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_small_lrf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_small_srf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_small_srf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_tiny_lrf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_tiny_lrf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/focalnet_tiny_srf.ms_in1k/model.py
+++ b/e2eshark/onnx/models/focalnet_tiny_srf.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gcvit_base/model.py
+++ b/e2eshark/onnx/models/gcvit_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gcvit_small/model.py
+++ b/e2eshark/onnx/models/gcvit_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gcvit_tiny/model.py
+++ b/e2eshark/onnx/models/gcvit_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gcvit_xtiny/model.py
+++ b/e2eshark/onnx/models/gcvit_xtiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gcvit_xxtiny/model.py
+++ b/e2eshark/onnx/models/gcvit_xxtiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gluon_xception65/model.py
+++ b/e2eshark/onnx/models/gluon_xception65/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(299, 299)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gmixer_24_224.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/gmixer_24_224.ra3_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/gmlp_s16_224.ra3_in1k/model.py
+++ b/e2eshark/onnx/models/gmlp_s16_224.ra3_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/ig_resnext101_32x48d/model.py
+++ b/e2eshark/onnx/models/ig_resnext101_32x48d/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/jx_nest_base/model.py
+++ b/e2eshark/onnx/models/jx_nest_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/jx_nest_small/model.py
+++ b/e2eshark/onnx/models/jx_nest_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/jx_nest_tiny/model.py
+++ b/e2eshark/onnx/models/jx_nest_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/lambda_resnet26t/model.py
+++ b/e2eshark/onnx/models/lambda_resnet26t/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/lambda_resnet50ts/model.py
+++ b/e2eshark/onnx/models/lambda_resnet50ts/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_128.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_128.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_128s.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_128s.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_192.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_192.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_256.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_256.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_384.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_384.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_conv_128.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_conv_128.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_conv_128s.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_conv_128s.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_conv_192.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_conv_192.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_conv_256.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_conv_256.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/levit_conv_384.fb_dist_in1k/model.py
+++ b/e2eshark/onnx/models/levit_conv_384.fb_dist_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_base_tf_224.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_base_tf_224.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_base_tf_384.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_base_tf_384.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_base_tf_384.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_base_tf_384.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_base_tf_512.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_base_tf_512.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_base_tf_512.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_base_tf_512.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_large_tf_224.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_large_tf_224.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_large_tf_384.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_large_tf_384.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_large_tf_384.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_large_tf_384.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_large_tf_512.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_large_tf_512.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_large_tf_512.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_large_tf_512.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_nano_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_nano_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_base_rw_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_base_rw_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_base_rw_224.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_base_rw_224.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_base_rw_384.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_base_rw_384.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_nano_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_nano_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_pico_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_pico_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_small_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_small_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_rmlp_tiny_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_rmlp_tiny_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_small_tf_224.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_small_tf_224.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_small_tf_384.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_small_tf_384.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_small_tf_512.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_small_tf_512.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_tiny_rw_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_tiny_rw_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_tiny_tf_224.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_tiny_tf_224.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_tiny_tf_384.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_tiny_tf_384.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_tiny_tf_512.in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_tiny_tf_512.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_xlarge_tf_384.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_xlarge_tf_384.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxvit_xlarge_tf_512.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxvit_xlarge_tf_512.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvit_rmlp_nano_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxxvit_rmlp_nano_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvit_rmlp_small_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxxvit_rmlp_small_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvitv2_nano_rw_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/maxxvitv2_nano_rw_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_224.sw_in12k/model.py
+++ b/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_224.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_224.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_224.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_384.sw_in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/maxxvitv2_rmlp_base_rw_384.sw_in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mixer_b16_224.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixer_b16_224.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mixer_b16_224.miil_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixer_b16_224.miil_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mixer_l16_224.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/mixer_l16_224.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevit_s/model.py
+++ b/e2eshark/onnx/models/mobilevit_s/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevit_xs/model.py
+++ b/e2eshark/onnx/models/mobilevit_xs/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevit_xxs/model.py
+++ b/e2eshark/onnx/models/mobilevit_xxs/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_050/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_050/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_075/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_075/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_100/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_100/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_125/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_125/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_150/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_150/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_150_384_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_150_384_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_150_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_150_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_175/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_175/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_175_384_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_175_384_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_175_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_175_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_200/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_200/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_200_384_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_200_384_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mobilevitv2_200_in22ft1k/model.py
+++ b/e2eshark/onnx/models/mobilevitv2_200_in22ft1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mvitv2_base/model.py
+++ b/e2eshark/onnx/models/mvitv2_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mvitv2_large/model.py
+++ b/e2eshark/onnx/models/mvitv2_large/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mvitv2_small/model.py
+++ b/e2eshark/onnx/models/mvitv2_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/mvitv2_tiny/model.py
+++ b/e2eshark/onnx/models/mvitv2_tiny/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/nasnetalarge/model.py
+++ b/e2eshark/onnx/models/nasnetalarge/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(331, 331)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_b_224/model.py
+++ b/e2eshark/onnx/models/pit_b_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_b_distilled_224/model.py
+++ b/e2eshark/onnx/models/pit_b_distilled_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_s_224/model.py
+++ b/e2eshark/onnx/models/pit_s_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_s_distilled_224/model.py
+++ b/e2eshark/onnx/models/pit_s_distilled_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_ti_224/model.py
+++ b/e2eshark/onnx/models/pit_ti_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_ti_distilled_224/model.py
+++ b/e2eshark/onnx/models/pit_ti_distilled_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_xs_224/model.py
+++ b/e2eshark/onnx/models/pit_xs_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pit_xs_distilled_224/model.py
+++ b/e2eshark/onnx/models/pit_xs_distilled_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pnasnet5large/model.py
+++ b/e2eshark/onnx/models/pnasnet5large/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(331, 331)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/poolformer_m36/model.py
+++ b/e2eshark/onnx/models/poolformer_m36/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/poolformer_m48/model.py
+++ b/e2eshark/onnx/models/poolformer_m48/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/poolformer_s12/model.py
+++ b/e2eshark/onnx/models/poolformer_s12/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/poolformer_s24/model.py
+++ b/e2eshark/onnx/models/poolformer_s24/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/poolformer_s36/model.py
+++ b/e2eshark/onnx/models/poolformer_s36/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b0/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b0/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b1/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b1/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b2/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b2/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b2_li/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b2_li/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b3/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b3/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b4/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b4/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/pvt_v2_b5/model.py
+++ b/e2eshark/onnx/models/pvt_v2_b5/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_120.sw_in12k/model.py
+++ b/e2eshark/onnx/models/regnety_120.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_1280.seer/model.py
+++ b/e2eshark/onnx/models/regnety_1280.seer/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_1280.seer_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_1280.seer_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_1280.swag_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_1280.swag_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_1280.swag_lc_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_1280.swag_lc_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_160.deit_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_160.deit_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_160.sw_in12k/model.py
+++ b/e2eshark/onnx/models/regnety_160.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_2560.seer_ft_in1k/model.py
+++ b/e2eshark/onnx/models/regnety_2560.seer_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_320.seer/model.py
+++ b/e2eshark/onnx/models/regnety_320.seer/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/regnety_640.seer/model.py
+++ b/e2eshark/onnx/models/regnety_640.seer/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resmlp_big_24_224.fb_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_big_24_224.fb_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resmlp_big_24_224.fb_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resmlp_big_24_224.fb_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnest200e/model.py
+++ b/e2eshark/onnx/models/resnest200e/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(320, 320)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnest269e/model.py
+++ b/e2eshark/onnx/models/resnest269e/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(416, 416)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnetrs270/model.py
+++ b/e2eshark/onnx/models/resnetrs270/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(352, 352)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnetrs350/model.py
+++ b/e2eshark/onnx/models/resnetrs350/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnetrs420/model.py
+++ b/e2eshark/onnx/models/resnetrs420/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(416, 416)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnetv2_101x3_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_101x3_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/resnetv2_152x4_bit.goog_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/resnetv2_152x4_bit.goog_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/rexnetr_200.sw_in12k/model.py
+++ b/e2eshark/onnx/models/rexnetr_200.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/rexnetr_300.sw_in12k/model.py
+++ b/e2eshark/onnx/models/rexnetr_300.sw_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(288, 288)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/sebotnet33ts_256/model.py
+++ b/e2eshark/onnx/models/sebotnet33ts_256/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/sequencer2d_l/model.py
+++ b/e2eshark/onnx/models/sequencer2d_l/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_base_patch4_window12_384.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_base_patch4_window12_384.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_base_patch4_window12_384.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_base_patch4_window12_384.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_base_patch4_window7_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_base_patch4_window7_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_base_patch4_window7_224.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_base_patch4_window7_224.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_large_patch4_window12_384.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_large_patch4_window12_384.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_large_patch4_window7_224.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_large_patch4_window7_224.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_s3_base_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_s3_base_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_s3_small_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_s3_small_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_s3_tiny_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_s3_tiny_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_small_patch4_window7_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_small_patch4_window7_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_small_patch4_window7_224.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_small_patch4_window7_224.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_tiny_patch4_window7_224.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swin_tiny_patch4_window7_224.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swin_tiny_patch4_window7_224.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swin_tiny_patch4_window7_224.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_base_window12to16_192to256.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_base_window12to16_192to256.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_base_window12to24_192to384.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_base_window12to24_192to384.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_base_window16_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_base_window16_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_base_window8_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_base_window8_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_cr_small_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_cr_small_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_cr_small_ns_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_cr_small_ns_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_cr_tiny_ns_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_cr_tiny_ns_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_large_window12to16_192to256.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_large_window12to16_192to256.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_large_window12to24_192to384.ms_in22k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_large_window12to24_192to384.ms_in22k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_small_window16_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_small_window16_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_small_window8_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_small_window8_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_tiny_window16_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_tiny_window16_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/swinv2_tiny_window8_256.ms_in1k/model.py
+++ b/e2eshark/onnx/models/swinv2_tiny_window8_256.ms_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b0.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b0.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b0.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b0.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b0.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b0.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b1.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b1.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b1.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b1.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b1.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b1.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b2.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b2.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(260, 260)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b2.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b2.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(260, 260)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b2.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b2.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(260, 260)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b3.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b3.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(300, 300)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b3.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b3.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(300, 300)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b3.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b3.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(300, 300)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b4.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b4.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(380, 380)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b4.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b4.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(380, 380)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b4.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b4.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(380, 380)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b5.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b5.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(456, 456)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b5.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b5.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(456, 456)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b5.ra_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b5.ra_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(456, 456)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b6.aa_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b6.aa_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(528, 528)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b6.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b6.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(528, 528)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b6.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b6.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(528, 528)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b7.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b7.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(600, 600)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b7.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b7.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(600, 600)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b7.ra_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b7.ra_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(600, 600)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b8.ap_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b8.ap_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(672, 672)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_b8.ra_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_b8.ra_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(672, 672)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_l2.ns_jft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_l2.ns_jft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(800, 800)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnet_l2.ns_jft_in1k_475/model.py
+++ b/e2eshark/onnx/models/tf_efficientnet_l2.ns_jft_in1k_475/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(475, 475)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_l.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_l.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(480, 480)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_l.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_l.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(480, 480)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_m.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_m.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(480, 480)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_m.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_m.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(480, 480)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_s.in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_s.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_s.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_s.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_efficientnetv2_xl.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/tf_efficientnetv2_xl.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(512, 512)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_mixnet_l.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mixnet_l.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_mixnet_m.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mixnet_m.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_mixnet_s.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mixnet_s.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_mobilenetv3_large_075.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_large_075.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tf_mobilenetv3_large_100.in1k/model.py
+++ b/e2eshark/onnx/models/tf_mobilenetv3_large_100.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tinynet_b.in1k/model.py
+++ b/e2eshark/onnx/models/tinynet_b.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(188, 188)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tinynet_c.in1k/model.py
+++ b/e2eshark/onnx/models/tinynet_c.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(184, 184)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tinynet_e.in1k/model.py
+++ b/e2eshark/onnx/models/tinynet_e.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(106, 106)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/tnt_s_patch16_224/model.py
+++ b/e2eshark/onnx/models/tnt_s_patch16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_pcpvt_base/model.py
+++ b/e2eshark/onnx/models/twins_pcpvt_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_pcpvt_large/model.py
+++ b/e2eshark/onnx/models/twins_pcpvt_large/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_pcpvt_small/model.py
+++ b/e2eshark/onnx/models/twins_pcpvt_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_svt_base/model.py
+++ b/e2eshark/onnx/models/twins_svt_base/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_svt_large/model.py
+++ b/e2eshark/onnx/models/twins_svt_large/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/twins_svt_small/model.py
+++ b/e2eshark/onnx/models/twins_svt_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/visformer_small/model.py
+++ b/e2eshark/onnx/models/visformer_small/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224.augreg2_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224.augreg2_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224.orig_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224.orig_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224.sam/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224.sam/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_224_miil.in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_224_miil.in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_384.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_384.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_384.orig_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_384.orig_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in12k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.openai/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.openai/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in12k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_224.openai_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_384.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_384.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_384.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_384.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_384.openai_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_384.openai_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_clip_384.openai_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_clip_384.openai_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch16_rpn_224.in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch16_rpn_224.in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_224.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_224.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_224.sam/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_224.sam/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_384.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_384.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_224.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_224.openai/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_224.openai/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_224.openai_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_224.openai_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_384.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_384.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_384.openai_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_384.openai_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch32_clip_448.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch32_clip_448.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(448, 448)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch8_224.augreg2_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch8_224.augreg2_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_patch8_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_patch8_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_base_r50_s16_384.orig_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_base_r50_s16_384.orig_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_giant_patch14_clip_224.laion2b/model.py
+++ b/e2eshark/onnx/models/vit_giant_patch14_clip_224.laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_gigantic_patch14_clip_224.laion2b/model.py
+++ b/e2eshark/onnx/models/vit_gigantic_patch14_clip_224.laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b/model.py
+++ b/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in12k/model.py
+++ b/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_huge_patch14_clip_224.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_huge_patch14_clip_336.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_huge_patch14_clip_336.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in12k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.openai/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.openai/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in12k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_224.openai_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_336.laion2b_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_336.laion2b_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(336, 336)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_336.laion2b_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_336.laion2b_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(336, 336)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch14_clip_336.openai_ft_in12k_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch14_clip_336.openai_ft_in12k_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(336, 336)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch16_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch16_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch16_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch16_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_patch32_384.orig_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_patch32_384.orig_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_r50_s32_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_r50_s32_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_large_r50_s32_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_large_r50_s32_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_medium_patch16_gap_240.in12k/model.py
+++ b/e2eshark/onnx/models/vit_medium_patch16_gap_240.in12k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(240, 240)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_medium_patch16_gap_256.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_medium_patch16_gap_256.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_medium_patch16_gap_384.in12k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_medium_patch16_gap_384.in12k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_base_patch16_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_base_patch16_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_base_patch16_clsgap_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_base_patch16_clsgap_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_base_patch32_plus_rpn_256.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_base_patch32_plus_rpn_256.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(256, 256)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_medium_patch16_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_medium_patch16_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_medium_patch16_cls_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_medium_patch16_cls_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_medium_patch16_rpn_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_medium_patch16_rpn_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_relpos_small_patch16_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_relpos_small_patch16_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch16_224.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch16_224.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch16_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch16_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch16_384.augreg_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch16_384.augreg_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch16_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch16_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch32_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch32_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_patch32_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_patch32_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_r26_s32_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_r26_s32_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_small_r26_s32_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_small_r26_s32_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_srelpos_medium_patch16_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_srelpos_medium_patch16_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_srelpos_small_patch16_224.sw_in1k/model.py
+++ b/e2eshark/onnx/models/vit_srelpos_small_patch16_224.sw_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_tiny_patch16_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_tiny_patch16_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_tiny_patch16_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_tiny_patch16_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_tiny_r_s16_p8_224.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_tiny_r_s16_p8_224.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/vit_tiny_r_s16_p8_384.augreg_in21k_ft_in1k/model.py
+++ b/e2eshark/onnx/models/vit_tiny_r_s16_p8_384.augreg_in21k_ft_in1k/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_large_24_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_large_24_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_medium_24_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_medium_24_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_nano_12_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_nano_12_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_12_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_12_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_small_24_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_small_24_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_12_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_12_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p16_224/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p16_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p16_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p16_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p16_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p16_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p8_224/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p8_224/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p8_224_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p8_224_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image()
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])

--- a/e2eshark/onnx/models/xcit_tiny_24_p8_384_dist/model.py
+++ b/e2eshark/onnx/models/xcit_tiny_24_p8_384_dist/model.py
@@ -1,0 +1,43 @@
+import numpy, torch, sys
+import onnxruntime
+
+# import from e2eshark/tools to allow running in current dir, for run through
+# run.pl, commutils is symbolically linked to allow any rundir to work
+sys.path.insert(0, "../../../tools/stubs")
+from commonutils import E2ESHARK_CHECK_DEF, to_numpy, setup_test_image
+
+# Create an instance of it for this test
+E2ESHARK_CHECK = dict(E2ESHARK_CHECK_DEF)
+
+
+# The generated or checked in onnx file must always be called model.onnx
+# the tools/stubs/onnxmodel.py is appended to model.py
+# to form runmodel.py in the rundirectory which is then taken
+# through flow
+
+
+# start an onnxrt session
+session = onnxruntime.InferenceSession("model.onnx", None)
+
+# Even if model is quantized, the inputs and outputs are
+# not, so apply float32
+# Get and process the image
+img_ycbcr = setup_test_image(384, 384)
+
+model_input_X = to_numpy(img_ycbcr)
+
+# gets X in inputs[0] and Y in inputs[1]
+inputs = session.get_inputs()
+# gets Z in outputs[0]
+outputs = session.get_outputs()
+
+
+model_output = session.run(
+    [outputs[0].name],
+    {inputs[0].name: model_input_X},
+)[0]
+E2ESHARK_CHECK["input"] = [torch.from_numpy(model_input_X)]
+E2ESHARK_CHECK["output"] = [torch.from_numpy(arr) for arr in model_output]
+
+print("Input:", E2ESHARK_CHECK["input"])
+print("Output:", E2ESHARK_CHECK["output"])


### PR DESCRIPTION
| items        |    tests |   model-run |   onnx-import |   torch-mlir |   iree-compile |   inference |
|:-------------|---------:|------------:|--------------:|-------------:|---------------:|------------:|
| total-count  | 530 |     500     |       500     |            129 |        73     |     16     |

full list (530): https://gist.github.com/jinchen62/cdf54ef8ed725fcce9d6fa18ecbfa058
failed on model-run (30): https://gist.github.com/jinchen62/1b23c9c227b772c7e7641fad39aa6ea9
failed on torch-mlir/iree-compile (411): https://gist.github.com/jinchen62/0ad6931179badcba0860f2da01b3cc21
failed on inference (73): https://gist.github.com/jinchen62/c870373258c5a1c71c975f81258463de

commands:
`python ./run.py  --tolerance 0.001 0.001 -c path/to/torch-mlir/build -i path/to/iree-build --cachedir path/to/cache -f onnx -g models --mode onnx --report -j 12 --testsfile model_list.txt`