### PR TITLE
[alt] Add some helper classes for making tests

### DIFF
--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -39,7 +39,11 @@ class SimpleIREEBackend(BackendBase):
         b = ireec.tools.compile_str(
             str(module),
             target_backends=[self.hal_target_backend],
-            extra_args=["--iree-input-demote-i64-to-i32"],
+            extra_args=[
+                "--iree-input-demote-i64-to-i32",
+                "--iree-llvmcpu-fail-on-large-vector=0",
+                "--iree-llvmcpu-stack-allocation-limit=300000",
+                ],
         )
         # log the vmfb
         if save_to:

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -41,8 +41,8 @@ class SimpleIREEBackend(BackendBase):
             target_backends=[self.hal_target_backend],
             extra_args=[
                 "--iree-input-demote-i64-to-i32",
-                "--iree-llvmcpu-fail-on-large-vector=0",
-                "--iree-llvmcpu-stack-allocation-limit=300000",
+                # "--iree-llvmcpu-fail-on-large-vector=0",
+                # "--iree-llvmcpu-stack-allocation-limit=300000",
                 ],
         )
         # log the vmfb

--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -94,21 +94,6 @@ class OnnxModelInfo:
         shapes, dtypes = self.get_signature(from_inputs=False)
         return TestTensors.load_from(shapes, dtypes, dir_path, "golden_output")
 
-class SiblingModel(OnnxModelInfo):
-    """convenience class for re-using an onnx model from another 'sibling' test"""
-    def __init__(self, og_model_info_class: type, og_name: str, *args, **kwargs):
-        self.og_name = og_name # name of original test
-        self.og_mic = og_model_info_class # this should be the OnnxModelInfo child class used by sibling test
-        super().__init__(*args, **kwargs)
-
-    def construct_model(self):
-        run_dir = Path(self.model).parents[1]
-        og_model_path = os.path.join(run_dir, self.og_name)
-        inst = self.og_mic(self.og_name, og_model_path)
-        if not os.path.exists(inst.model):
-            inst.construct_model()
-        self.model = inst.model
-
 # TODO: extend TestModel to a union, or make TestModel a base class when supporting other frontends
 TestModel = OnnxModelInfo 
 CompiledArtifact = TypeVar("CompiledArtifact")

--- a/alt_e2eshark/e2e_testing/onnx_utils.py
+++ b/alt_e2eshark/e2e_testing/onnx_utils.py
@@ -104,3 +104,9 @@ def node_output_name(model: onnx.ModelProto, n: int, op_name: str) -> str:
     if not node:
         raise ValueError(f"Could not find {n} nodes of type {op_name} in {model}")
     return node.output[0]
+
+def node_name_from_back(model: onnx.ModelProto, n: int) -> str:
+    """returns the name of the node appearing 'n' nodes from the back"""
+    nde = model.graph.node[-n]
+    return nde.output[0]
+

--- a/alt_e2eshark/e2e_testing/onnx_utils.py
+++ b/alt_e2eshark/e2e_testing/onnx_utils.py
@@ -75,38 +75,81 @@ def get_signature_for_onnx_model(model_path, *, from_inputs: bool = True):
         dtypes.append(dtype_from_ort_node(i))
     return shapes, dtypes
 
+def get_op_frequency(model_path):
+    model = onnx.load(model_path)
+    op_freq = dict()
+    for n in model.graph.node:
+        if n.op_type in op_freq:
+            op_freq[n.op_type] += 1
+        else:
+            op_freq[n.op_type] = 1
+    return op_freq
 
 def modify_model_output(
-    model: onnx.ModelProto, new_output_name: str
+    model: onnx.ModelProto, final_node_key: int
 ) -> onnx.ModelProto:
-    """A helper function to change the output of an onnx model to a new output. Helpful to use with node_output_name"""
-    if len(model.graph.output) != 1:
-        raise NotImplementedError(
-            "This function currently only supports modifying models with one output."
-        )
+    """A helper function to change the output of an onnx model to a new output."""
+
+    final_node = model.graph.node[final_node_key]
+
+    # clear old outputs
+    n = len(model.graph.output)
+    for _ in range(n):
+        model.graph.output.pop()
+
+    # add new outputs
     for vi in model.graph.value_info:
-        if vi.name == new_output_name:
-            model.graph.output.pop()
+        if vi.name in final_node.output:
             model.graph.output.append(vi)
+    
+    # remove nodes after the final output
+    for _ in range(final_node_key+1, len(model.graph.node)):
+        model.graph.node.pop()
+    
+    # remove unused nodes, inputs, value_info, and initializers before final output
+    keep_node_names, keep_vi_names = find_minimal_graph(model.graph, final_node_key)
+    def remove_unused(model: onnx.ModelProto, attr: str, keep_list):
+        i = 0
+        while i < len(model.graph.__getattribute__(attr)):
+            obj = model.graph.__getattribute__(attr)[i]
+            if obj.name not in keep_list:
+                model.graph.__getattribute__(attr).pop(i)
+            else:
+                i += 1
+
+    remove_unused(model, "node", keep_node_names)
+    remove_unused(model, "input", keep_vi_names)
+    remove_unused(model, "value_info", keep_vi_names)
+    remove_unused(model, "initializer", keep_vi_names)
     return model
 
+def find_minimal_graph(graph: onnx.GraphProto, top_key: int):
+    keep_vi_names = set()
+    keep_vi_names.update(set(graph.node[top_key].output))
+    keep_names = set()
+    i = top_key
+    while i >= 0:
+        node = graph.node[i]
+        if len(set(node.output).intersection(keep_vi_names)) != 0:
+            keep_names.add(node.name)
+            keep_vi_names.update(set(node.input))
+        i -= 1
 
-def node_output_name(model: onnx.ModelProto, n: int, op_name: str) -> str:
-    """returns the output name for the nth node in the onnx model with op_type given by op_name"""
-    counter = 0
+    return keep_names, keep_vi_names
+
+def find_node(model: onnx.ModelProto, n: int, op_name: str) -> onnx.NodeProto:
+    """returns the output names for the nth node in the onnx model with op_type given by op_name"""
+    match_counter = 0
+    key = -1
     for nde in model.graph.node:
+        key += 1
         if nde.op_type != op_name:
             continue
-        if counter == n:
+        if match_counter == n:
             node = nde
             break
-        counter += 1
+        match_counter += 1
     if not node:
         raise ValueError(f"Could not find {n} nodes of type {op_name} in {model}")
-    return node.output[0]
-
-def node_name_from_back(model: onnx.ModelProto, n: int) -> str:
-    """returns the name of the node appearing 'n' nodes from the back"""
-    nde = model.graph.node[-n]
-    return nde.output[0]
+    return key
 

--- a/alt_e2eshark/e2e_testing/onnx_utils.py
+++ b/alt_e2eshark/e2e_testing/onnx_utils.py
@@ -75,6 +75,7 @@ def get_signature_for_onnx_model(model_path, *, from_inputs: bool = True):
         dtypes.append(dtype_from_ort_node(i))
     return shapes, dtypes
 
+
 def get_op_frequency(model_path):
     model = onnx.load(model_path)
     op_freq = dict()
@@ -85,9 +86,8 @@ def get_op_frequency(model_path):
             op_freq[n.op_type] = 1
     return op_freq
 
-def modify_model_output(
-    model: onnx.ModelProto, final_node_key: int
-) -> onnx.ModelProto:
+
+def modify_model_output(model: onnx.ModelProto, final_node_key: int) -> onnx.ModelProto:
     """A helper function to change the output of an onnx model to a new output."""
 
     final_node = model.graph.node[final_node_key]
@@ -101,14 +101,15 @@ def modify_model_output(
     for vi in model.graph.value_info:
         if vi.name in final_node.output:
             model.graph.output.append(vi)
-    
+
     # remove nodes after the final output
-    for _ in range(final_node_key+1, len(model.graph.node)):
+    for _ in range(final_node_key + 1, len(model.graph.node)):
         model.graph.node.pop()
-    
+
     # remove unused nodes, inputs, value_info, and initializers before final output
     keep_node_names, keep_vi_names = find_minimal_graph(model.graph, final_node_key)
-    def remove_unused(model: onnx.ModelProto, attr: str, keep_list):
+
+    def remove_unused(attr: str, keep_list):
         i = 0
         while i < len(model.graph.__getattribute__(attr)):
             obj = model.graph.__getattribute__(attr)[i]
@@ -117,11 +118,12 @@ def modify_model_output(
             else:
                 i += 1
 
-    remove_unused(model, "node", keep_node_names)
-    remove_unused(model, "input", keep_vi_names)
-    remove_unused(model, "value_info", keep_vi_names)
-    remove_unused(model, "initializer", keep_vi_names)
+    remove_unused("node", keep_node_names)
+    remove_unused("input", keep_vi_names)
+    remove_unused("value_info", keep_vi_names)
+    remove_unused("initializer", keep_vi_names)
     return model
+
 
 def find_minimal_graph(graph: onnx.GraphProto, top_key: int):
     keep_vi_names = set()
@@ -136,6 +138,7 @@ def find_minimal_graph(graph: onnx.GraphProto, top_key: int):
         i -= 1
 
     return keep_names, keep_vi_names
+
 
 def find_node(model: onnx.ModelProto, n: int, op_name: str) -> onnx.NodeProto:
     """returns the output names for the nth node in the onnx model with op_type given by op_name"""
@@ -152,4 +155,3 @@ def find_node(model: onnx.ModelProto, n: int, op_name: str) -> onnx.NodeProto:
     if not node:
         raise ValueError(f"Could not find {n} nodes of type {op_name} in {model}")
     return key
-

--- a/alt_e2eshark/onnx_tests/combinations/model.py
+++ b/alt_e2eshark/onnx_tests/combinations/model.py
@@ -5,4 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .multi_conv import *
+from .quant_relu import *
+from .quant_resize import *
 from .shape_cos import *

--- a/alt_e2eshark/onnx_tests/combinations/quant_relu.py
+++ b/alt_e2eshark/onnx_tests/combinations/quant_relu.py
@@ -1,0 +1,25 @@
+from ..helper_classes import BuildAModel
+from onnx import TensorProto
+from onnx.helper import make_tensor, make_tensor_value_info
+from e2e_testing.registry import register_test
+
+class QuantizedRelu(BuildAModel):
+    def construct_nodes(self):
+        app_node = self.get_app_node()
+
+        ST = make_tensor("ST", TensorProto.FLOAT, [], [0.025])
+        ZPT = make_tensor("ZPT", TensorProto.INT8, [], [3])
+
+        app_node("Constant", [], ["S"], value=ST)
+        app_node("Constant", [], ["ZP"], value=ZPT)
+        app_node("QuantizeLinear", ["X", "S", "ZP"], ["QX"])
+        app_node("DequantizeLinear", ["QX", "S", "ZP"], ["DQX"])
+        app_node("Relu", ["DQX"], ["Y"])
+        app_node("QuantizeLinear", ["Y", "S", "ZP"], ["QY"])
+        app_node("DequantizeLinear", ["QY", "S", "ZP"], ["DQY"])
+    
+    def construct_i_o_value_info(self):
+        self.input_vi.append(make_tensor_value_info("X", TensorProto.FLOAT, [1,2,4]))
+        self.output_vi.append(make_tensor_value_info("DQY", TensorProto.FLOAT, [1,2,4]))
+
+register_test(QuantizedRelu, "quantized_relu")

--- a/alt_e2eshark/onnx_tests/combinations/quant_resize.py
+++ b/alt_e2eshark/onnx_tests/combinations/quant_resize.py
@@ -1,0 +1,106 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from onnx import TensorProto
+import torch
+from onnx.helper import (
+    make_node,
+    make_tensor_value_info,
+    make_tensor,
+)
+
+from ..helper_classes import BuildAModel
+from e2e_testing.storage import TestTensors
+from e2e_testing.registry import register_test
+
+class ResizeTransposeQModel(BuildAModel):
+    def construct_nodes(self):
+        app_node = self.get_app_node()
+
+        ST = make_tensor("ST",TensorProto.FLOAT, [], [0.25])
+        ZPT = make_tensor("ZPT",TensorProto.INT8, [], [0])
+        C0T = make_tensor("C0T",TensorProto.FLOAT, [4], [1.0, 1.0, 7.89230776, 7.89230776])
+        C1T = make_tensor("C1T",TensorProto.FLOAT, [8], [0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0])
+
+        app_node("Constant",[],["S"],value=ST)
+        app_node("Constant",[],["ZP"],value=ZPT)
+        app_node("Constant",[],["C0"],value=C0T)
+        app_node("Constant",[],["C1"],value=C1T)
+
+        app_node("QuantizeLinear",["X0","S","ZP"], ["QX0"])
+        app_node("DequantizeLinear", ["QX0","S","ZP"], ["DQX0"])
+        app_node("Resize",["DQX0","C1","C0"],["X1"], mode="linear")
+        app_node("QuantizeLinear",["X1","S","ZP"], ["QX1"])
+        app_node("DequantizeLinear", ["QX1","S","ZP"], ["DQX1"])
+        app_node("Transpose", ["DQX1"], ["X2"], perm = [0, 2, 3, 1]) 
+        app_node("QuantizeLinear",["X2","S","ZP"], ["QX2"])
+        app_node("DequantizeLinear", ["QX2","S","ZP"], ["DQX2"])
+    
+    def construct_i_o_value_info(self):
+        self.input_vi.append(make_tensor_value_info("X0", TensorProto.FLOAT, [1, 21, 65, 65]))
+        self.output_vi.append(make_tensor_value_info("DQX2", TensorProto.FLOAT, [1, 513, 513, 21]))
+
+register_test(ResizeTransposeQModel, "resize_tq")
+
+class SmallerResizeTQModel(ResizeTransposeQModel):
+    def construct_inputs(self):
+        # input = torch.Tensor([[[[0.42, 0.93], [0.27, 0.06]]]]).to(dtype=torch.float32)
+        # this is the quantized result:
+        input = torch.Tensor([[[[0.5, 1.0], [0.25, 0.00]]]]).to(dtype=torch.float32) 
+        return TestTensors((input,))
+
+    def construct_nodes(self):
+        app_node = self.get_app_node()
+        ST = make_tensor("ST",TensorProto.FLOAT, [], [0.25])
+        ZPT = make_tensor("ZPT",TensorProto.INT8, [], [0])
+        C0T = make_tensor("C0T",TensorProto.FLOAT, [4], [1.0, 1.0, 1.5, 1.5])
+
+        app_node("Constant",[],["S"],value=ST)
+        app_node("Constant",[],["ZP"],value=ZPT)
+        app_node("Constant",[],["C0"],value=C0T)
+
+        app_node("QuantizeLinear",["X0","S","ZP"], ["QX0"])
+        app_node("DequantizeLinear", ["QX0","S","ZP"], ["DQX0"])
+        app_node("Resize",["DQX0","","C0"],["X1"], mode="linear")
+        app_node("QuantizeLinear",["X1","S","ZP"], ["QX1"])
+        app_node("DequantizeLinear", ["QX1","S","ZP"], ["DQX1"])
+        app_node("Transpose", ["DQX1"], ["X2"], perm = [0, 2, 3, 1]) 
+    
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X0", TensorProto.FLOAT, [1, 1, 2, 2])]
+        # output_vi = [make_tensor_value_info("DQX1", TensorProto.FLOAT, [1, 1, 4, 4])]
+        self.output_vi = [make_tensor_value_info("X2", TensorProto.FLOAT, [1, 3, 3, 1])]
+
+register_test(SmallerResizeTQModel, "resize_tq_0")
+
+class SmallResizeIdentityQ(SmallerResizeTQModel):
+    def construct_nodes(self):
+        super().construct_nodes()
+        self.node_list.pop()
+        self.node_list.append(make_node("Identity", ["DQX1"],["X2"]))
+
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X0", TensorProto.FLOAT, [1, 1, 2, 2])]
+        self.output_vi = [make_tensor_value_info("X2", TensorProto.FLOAT, [1, 1, 3, 3])]
+
+register_test(SmallResizeIdentityQ, "resize_tq_1")
+
+class SmallResizeIdentityQ2(SmallerResizeTQModel):
+    def construct_nodes(self):
+        super().construct_nodes()
+        self.node_list.pop()
+
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X0", TensorProto.FLOAT, [1, 1, 2, 2])]
+        self.output_vi = [make_tensor_value_info("DQX1", TensorProto.FLOAT, [1, 1, 3, 3])]
+
+register_test(SmallResizeIdentityQ2, "resize_tq_2")
+
+class SmallResizeIdentityQ3(SmallResizeIdentityQ):
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X0", TensorProto.FLOAT, [1, 1, 2, 2])]
+        self.output_vi = [make_tensor_value_info("DQX1", TensorProto.FLOAT, [1, 1, 3, 3])]
+
+register_test(SmallResizeIdentityQ3, "resize_tq_3")

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -1,0 +1,174 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import os
+import onnx
+from onnx.helper import make_node, make_graph, make_model
+from pathlib import Path
+from e2e_testing.framework import OnnxModelInfo
+from e2e_testing.onnx_utils import (
+    modify_model_output,
+    node_output_name,
+    node_name_from_back,
+)
+
+"""This file contains several helpful child classes of OnnxModelInfo."""
+
+
+class SiblingModel(OnnxModelInfo):
+    """convenience class for re-using an onnx model from another 'sibling' test"""
+
+    def __init__(self, og_model_info_class: type, og_name: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # additionally store an instance of the sibling test
+        run_dir = Path(self.model).parents[1]
+        og_model_path = os.path.join(run_dir, og_name)
+        self.sibling_inst = og_model_info_class(og_name, og_model_path)
+
+    def construct_model(self):
+        if not os.path.exists(self.sibling_inst.model):
+            self.sibling_inst.construct_model()
+        self.model = self.sibling_inst.model
+
+
+def get_sibling_constructor(sibling_class, og_constructor, og_name):
+    """Returns a constructor for the sibling class. Useful for convenient registration.
+
+    Usage:
+
+    class OGModelInfoClass:
+        ...
+
+    register_test(OGModelInfoClass, og_name)
+
+    class NewSiblingModel(SiblingModel):
+        ...
+
+    sibling_constructor = get_sibling_constructor(NewSiblingModel, OGModelInfoClass, og_name)
+    register_test(sibling_constructor, new_name)
+
+    """
+    return lambda *args, **kwargs: sibling_class(
+        og_constructor, og_name, *args, **kwargs
+    )
+
+
+class TruncatedModel(SiblingModel):
+    """This class will take the model.onnx from another test, and modify the output.
+
+    Takes additional __init__ args: n (int) and op_type (str)
+    If op_type = "", n will determine the position backwards from the original output node.
+    If op_type isn't a null string, then n will be used to determine which node of that op_type will be returned as an output.
+
+    Examples:
+    op_type = "Conv" and n=2: This will set the output of the onnx model to the ouptput of the third Conv node in the graph.
+    op_type = "" and n=2: This will set the output of the model to the second-to-last node before the original output.
+    """
+
+    def __init__(self, n: int, op_type: str, *args, **kwargs):
+        self.n = n
+        self.op_type = op_type
+        super().__init__(*args, **kwargs)
+
+    def construct_model(self):
+        if not os.path.exists(self.sibling_inst.model):
+            self.sibling_inst.construct_model()
+        og_model = onnx.load(self.sibling_inst.model)
+        inf_model = onnx.shape_inference.infer_shapes(og_model, data_prop=True)
+        output_name = (
+            node_name_from_back(inf_model, self.n)
+            if self.op_type == ""
+            else node_output_name(inf_model, self.n, self.op_type)
+        )
+        new_model = modify_model_output(inf_model, output_name)
+        onnx.save(new_model, self.model)
+
+
+def get_trucated_constructor(truncated_class, og_constructor, og_name):
+    """returns a function that takes in (n, op_type) and returns a constructor for the truncated class.
+
+    Usage:
+
+    class OGModelInfoClass:
+        ...
+
+    register_test(OGModelInfoClass, og_name)
+
+    class NewTruncatedModel(TruncatedModel):
+        ...
+
+    truncated_constructor = get_truncated_constructor(NewTruncatedModel, OGModelInfoClass, og_name)
+    register_test(truncated_constructor(2, "Conv"), og_name + "_2_Conv")
+    register_test(truncated_constructor(5, ""), og_name + "_5")
+
+    """
+    return lambda n, op_type: (
+        lambda *args, **kwargs: truncated_class(
+            n, op_type, og_constructor, og_name, *args, **kwargs
+        )
+    )
+
+
+class BuildAModel(OnnxModelInfo):
+    """Convenience class for building an onnx model from scratch.
+    If inheriting from this class:
+    1. override construct_nodes(self) to add to the self.node_list. The get_app_node method may be helpful.
+    2. override construct_i_o_value_info to add the input and output value infos to the lists self.input_vi and self.output_vi.
+    3. optionally override other OnnxModelInfo methods if desired, e.g. construct_inputs.
+
+    Example:
+
+    class QuantizedRelu(BuildAModel):
+        def construct_nodes(self):
+            app_node = self.get_app_node()
+
+            ST = make_tensor("ST", TensorProto.FLOAT, [], [0.025])
+            ZPT = make_tensor("ZPT", TensorProto.INT8, [], [3])
+
+            app_node("Constant", [], ["S"], value=ST)
+            app_node("Constant", [], ["ZP"], value=ZPT)
+            app_node("QuantizeLinear", ["X", "S", "ZP"], ["QX"])
+            app_node("DequantizeLinear", ["QX", "S", "ZP"], ["DQX"])
+            app_node("Relu", ["DQX"], ["Y"])
+            app_node("QuantizeLinear", ["Y", "S", "ZP"], ["QY"])
+            app_node("DequantizeLinear", ["QY", "S", "ZP"], ["DQY"])
+
+        def construct_i_o_value_info(self):
+            self.input_vi.append(make_tensor_value_info("X", TensorProto.FLOAT, [1,2,4]))
+            self.output_vi.append(make_tensor_value_info("DQY", TensorProto.FLOAT, [1,2,4]))
+
+    register_test(QuantizedRelu, "quantized_relu")
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # always construct the onnx model for these tests.
+        # Useful for trial-error building of the test without having to delete the old onnx model.
+        self.node_list = []
+        self.input_vi = []
+        self.output_vi = []
+        self.construct_model()
+
+    def construct_nodes(self):
+        """Needs to be overriden. Update self.node_list here with the nodes you want in your graph."""
+        raise NotImplementedError("Please implement a construct_nodes method.")
+
+    def construct_i_o_value_info(self):
+        """Needs to be overridden. Update self.input_vi and self.output_vi with the lists of input and output value infos"""
+        raise NotImplementedError("Please implement a construct_i_o_value_info method.")
+
+    def get_app_node(self):
+        """Convenience function for defining a lambda that appends a new node to self.node_list"""
+        return lambda op_type, inputs, outputs, **kwargs: self.node_list.append(
+            make_node(op_type, inputs, outputs, **kwargs)
+        )
+
+    def construct_model(self):
+        self.construct_nodes()
+        self.construct_i_o_value_info()
+        graph = make_graph(self.node_list, "main", self.input_vi, self.output_vi)
+        model = make_model(graph)
+        onnx.save(model, self.model)

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -7,6 +7,7 @@ import os
 import onnx
 from onnx.helper import make_node, make_graph, make_model
 from pathlib import Path
+from e2e_testing import azutils
 from e2e_testing.framework import OnnxModelInfo
 from e2e_testing.onnx_utils import (
     modify_model_output,
@@ -15,6 +16,50 @@ from e2e_testing.onnx_utils import (
 )
 
 """This file contains several helpful child classes of OnnxModelInfo."""
+
+class AzureDownloadableModel(OnnxModelInfo):
+    """This class can be used for models in our azure storage (both private and public)."""
+    def __init__(self, name: str, onnx_model_path: str):
+        opset_version = 21
+        parent_cache_dir = os.getenv('CACHE_DIR')
+        if not parent_cache_dir:
+            raise RuntimeError("Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files.")
+        self.cache_dir = os.path.join(parent_cache_dir, name)
+        super().__init__(name, onnx_model_path, opset_version)
+
+    def construct_model(self):
+        # try to find a .onnx file in the test-run dir
+        # if that fails, check for zip file in cache
+        # if that fails, try to download and setup from azure, then search again for a .onnx file
+
+        # TODO: make the zip file structure more uniform so we don't need to search for extracted files
+        model_dir = str(Path(self.model).parent)
+
+        def find_models(model_dir):
+            # search for a .onnx file in the ./test-run/testname/ dir
+            found_models = []
+            for root, dirs, files in os.walk(model_dir):
+                for name in files:
+                    if name[-5:] == ".onnx":  
+                        found_models.append(os.path.abspath(os.path.join(root, name)))
+            return found_models
+
+        found_models = find_models(model_dir) 
+
+        if len(found_models) == 0:
+            azutils.pre_test_onnx_model_azure_download(
+                self.name, self.cache_dir, self.model
+            )
+            found_models = find_models(model_dir)
+        if len(found_models) == 1:
+            self.model = found_models[0]
+            return
+        if len(found_models) > 1:
+            print(f'Found multiple model.onnx files: {found_models}')
+            print(f'Picking the first model found to use: {found_models[0]}')
+            self.model = found_models[0]
+            return
+        raise OSError(f"No onnx model could be found, downloaded, or extracted to {model_dir}")
 
 
 class SiblingModel(OnnxModelInfo):

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -200,6 +200,7 @@ class BuildAModel(OnnxModelInfo):
         self.node_list = []
         self.input_vi = []
         self.output_vi = []
+        self.initializers = None
         self.construct_model()
 
     def construct_nodes(self):
@@ -210,6 +211,10 @@ class BuildAModel(OnnxModelInfo):
         """Needs to be overridden. Update self.input_vi and self.output_vi with the lists of input and output value infos"""
         raise NotImplementedError("Please implement a construct_i_o_value_info method.")
 
+    def construct_initializers(self):
+        """Can be overridden. Use to define self.initializers as a list of TensorProtos."""
+        pass
+
     def get_app_node(self):
         """Convenience function for defining a lambda that appends a new node to self.node_list"""
         return lambda op_type, inputs, outputs, **kwargs: self.node_list.append(
@@ -219,6 +224,7 @@ class BuildAModel(OnnxModelInfo):
     def construct_model(self):
         self.construct_nodes()
         self.construct_i_o_value_info()
-        graph = make_graph(self.node_list, "main", self.input_vi, self.output_vi)
+        self.construct_initializers()
+        graph = make_graph(self.node_list, "main", self.input_vi, self.output_vi, self.initializers)
         model = make_model(graph)
         onnx.save(model, self.model)

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -3,55 +3,8 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import os
-from pathlib import Path
-from e2e_testing import azutils
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import AzureDownloadableModel
 from e2e_testing.registry import register_test
-
-CACHE_DIR = os.getenv('CACHE_DIR')
-
-class AzureDownloadableModel(OnnxModelInfo):
-    def __init__(self, name: str, onnx_model_path: str):
-        opset_version = 21
-        if not CACHE_DIR:
-            raise RuntimeError("Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files.")
-        self.cache_dir = os.path.join(CACHE_DIR, name)
-        super().__init__(name, onnx_model_path, opset_version)
-
-    def construct_model(self):
-        # try to find a .onnx file in the test-run dir
-        # if that fails, check for zip file in cache
-        # if that fails, try to download and setup from azure, then search again for a .onnx file
-
-        # TODO: make the zip file structure more uniform so we don't need to search for extracted files
-        model_dir = str(Path(self.model).parent)
-
-        def find_models(model_dir):
-            # search for a .onnx file in the ./test-run/testname/ dir
-            found_models = []
-            for root, dirs, files in os.walk(model_dir):
-                for name in files:
-                    if name[-5:] == ".onnx":  
-                        found_models.append(os.path.abspath(os.path.join(root, name)))
-            return found_models
-
-        found_models = find_models(model_dir) 
-
-        if len(found_models) == 0:
-            azutils.pre_test_onnx_model_azure_download(
-                self.name, self.cache_dir, self.model
-            )
-            found_models = find_models(model_dir)
-        if len(found_models) == 1:
-            self.model = found_models[0]
-            return
-        if len(found_models) > 1:
-            print(f'Found multiple model.onnx files: {found_models}')
-            print(f'Picking the first model found to use: {found_models[0]}')
-            self.model = found_models[0]
-            return
-        raise OSError(f"No onnx model could be found, downloaded, or extracted to {model_dir}")
 
 # If the azure model is simple enough to use the default input generation in e2e_testing/onnx_utils.py, then add the name to the list here.
 # Note: several of these models will likely fail numerics without further post-processing. Consider writing a custom child class if further post-processing is desired. 

--- a/alt_e2eshark/onnx_tests/models/deeplab.py
+++ b/alt_e2eshark/onnx_tests/models/deeplab.py
@@ -9,7 +9,7 @@ import urllib
 from pathlib import Path
 from PIL import Image
 from torchvision import transforms
-from e2e_testing.framework import SiblingModel
+from ..helper_classes import SiblingModel, get_sibling_constructor
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
 from .azure_models import AzureDownloadableModel
@@ -82,5 +82,5 @@ class DeeplabModel(SiblingModel):
 register_test(AzureDownloadableModel, "deeplabv3")
 
 # sibling test with all the bells & whistles
-constructor = lambda *args, **kwargs : DeeplabModel(AzureDownloadableModel, "deeplabv3", *args, **kwargs)
+constructor = get_sibling_constructor(DeeplabModel, AzureDownloadableModel, "deeplabv3")
 register_test(constructor, "deeplabv3_real_with_pp")

--- a/alt_e2eshark/onnx_tests/models/deeplab.py
+++ b/alt_e2eshark/onnx_tests/models/deeplab.py
@@ -4,15 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import numpy
+import onnxruntime
 import torch
 import urllib
 from pathlib import Path
 from PIL import Image
 from torchvision import transforms
-from ..helper_classes import SiblingModel, get_sibling_constructor
+from ..helper_classes import AzureDownloadableModel, SiblingModel, get_sibling_constructor
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
-from .azure_models import AzureDownloadableModel
 
 label_map = numpy.array([
     (0, 0, 0),  # background
@@ -39,6 +39,9 @@ label_map = numpy.array([
 ])
 
 class DeeplabModel(SiblingModel):
+    def update_sess_options(self):
+        self.sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+
     def construct_inputs(self):
         filename = str(Path(self.model).parent.joinpath("input.png"))
         url = "https://github.com/pytorch/hub/raw/master/images/deeplab1.png"
@@ -47,22 +50,38 @@ class DeeplabModel(SiblingModel):
         input_image = Image.open(filename)
         input_image = input_image.convert("RGB")
         self.img_size = input_image.size
+        (shapes, dtypes) = self.get_signature(from_inputs=True)
+        self.shape = shapes[0]
+        if self.shape[1] == 3:
+            self.spatial_shape = self.shape[2:]
+            self.channels_last = False
+        elif self.shape[3] == 3:
+            self.spatial_shape = self.shape[1:3]
+            self.channels_last = True
+        else:
+            return ValueError("Expected the input shape to have three channels (RGB)")
         preprocess = transforms.Compose([
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-            transforms.Resize((513,513)),
+            transforms.Resize(self.spatial_shape),
         ])
         input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(0).transpose(1,2).transpose(2,3)
-        return TestTensors((input_batch,))
+        input_tensor = input_tensor.unsqueeze(0)
+        if self.channels_last:
+            input_tensor = input_tensor.transpose(1,2).transpose(2,3)
+        return TestTensors((input_tensor,))
 
     def apply_postprocessing(self, output: TestTensors):
         processed_outputs = []
         for d in output.to_torch().data:
-            c = torch.topk(torch.nn.functional.softmax(d, -1), 2)[-1][0,:,:,-1]
-            image = numpy.zeros([513,513,3]).astype(numpy.uint8)
-            for i in range(513):
-                for j in range(513):
+            if self.channels_last:
+                c = torch.topk(torch.nn.functional.softmax(d, -1), 2)[-1][0,:,:,-1]
+            else:
+                c = torch.topk(torch.nn.functional.softmax(d, 1), 2, 1)[-1][0,-1,:,:]
+
+            image = numpy.zeros((self.spatial_shape[0], self.spatial_shape[1], 3)).astype(numpy.uint8)
+            for i in range(self.spatial_shape[0]):
+                for j in range(self.spatial_shape[1]):
                     for k in range(3):
                         image[i,j,k] = label_map[c[i,j]][k]
             processed_outputs.append(image)
@@ -80,7 +99,10 @@ class DeeplabModel(SiblingModel):
 
 # base test (no post-processing or input mods)
 register_test(AzureDownloadableModel, "deeplabv3")
+register_test(AzureDownloadableModel, "DeepLabV3_resnet50_vaiq_int8")
 
 # sibling test with all the bells & whistles
-constructor = get_sibling_constructor(DeeplabModel, AzureDownloadableModel, "deeplabv3")
-register_test(constructor, "deeplabv3_real_with_pp")
+constructor0 = get_sibling_constructor(DeeplabModel, AzureDownloadableModel, "deeplabv3")
+constructor1 = get_sibling_constructor(DeeplabModel, AzureDownloadableModel, "DeepLabV3_resnet50_vaiq_int8")
+register_test(constructor0, "deeplabv3_real_with_pp")
+register_test(constructor1, "DeepLabV3_resnet50_vaiq_int8_real_with_pp")

--- a/alt_e2eshark/onnx_tests/models/opt_models.py
+++ b/alt_e2eshark/onnx_tests/models/opt_models.py
@@ -8,7 +8,7 @@ import torch
 from e2e_testing.framework import OnnxModelInfo
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
-from .azure_models import AzureDownloadableModel
+from ..helper_classes import AzureDownloadableModel
 
 
 class Opt125MAWQModelInfo(AzureDownloadableModel):

--- a/alt_e2eshark/onnx_tests/models/vision_models.py
+++ b/alt_e2eshark/onnx_tests/models/vision_models.py
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import torch
-from e2e_testing.framework import OnnxModelInfo, SiblingModel
+from ..helper_classes import SiblingModel, get_sibling_constructor
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
 from .azure_models import AzureDownloadableModel
@@ -19,8 +19,8 @@ class ImageClassificationModel(SiblingModel):
         return TestTensors(processed_outputs)
 
 # this will run resnet50_vaiq_int8 without post-processing
-register_test(AzureDownloadableModel, "resnet50_vaiq_int8")
+register_test(AzureDownloadableModel, "ResNet50_vaiq")
 
 # this will run the same model, but with post-processing
-constructor = lambda *args, **kwargs : ImageClassificationModel(AzureDownloadableModel, "resnet50_vaiq_int8", *args, **kwargs)
-register_test(constructor, "resnet50_vaiq_int8_pp")
+constructor = get_sibling_constructor(ImageClassificationModel, AzureDownloadableModel, "ResNet50_vaiq")
+register_test(constructor, "ResNet50_vaiq_pp")

--- a/alt_e2eshark/onnx_tests/models/vision_models.py
+++ b/alt_e2eshark/onnx_tests/models/vision_models.py
@@ -4,10 +4,14 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import torch
-from ..helper_classes import SiblingModel, get_sibling_constructor
+import onnxruntime
+from ..helper_classes import AzureDownloadableModel, SiblingModel, get_sibling_constructor
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
-from .azure_models import AzureDownloadableModel
+
+class NoOptimizations(SiblingModel):
+    def update_sess_options(self):
+        self.sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
 
 class ImageClassificationModel(SiblingModel):
     def apply_postprocessing(self, output: TestTensors):
@@ -19,8 +23,21 @@ class ImageClassificationModel(SiblingModel):
         return TestTensors(processed_outputs)
 
 # this will run resnet50_vaiq_int8 without post-processing
+register_test(AzureDownloadableModel, "resnet50_vaiq_int8")
 register_test(AzureDownloadableModel, "ResNet50_vaiq")
 
 # this will run the same model, but with post-processing
-constructor = get_sibling_constructor(ImageClassificationModel, AzureDownloadableModel, "ResNet50_vaiq")
-register_test(constructor, "ResNet50_vaiq_pp")
+constructor0 = get_sibling_constructor(ImageClassificationModel, AzureDownloadableModel, "resnet50_vaiq_int8")
+constructor1 = get_sibling_constructor(ImageClassificationModel, AzureDownloadableModel, "ResNet50_vaiq")
+register_test(constructor0, "resnet50_vaiq_int8_pp")
+register_test(constructor1, "ResNet50_vaiq_pp")
+
+# this will run the same model, but the gold inference will be generated without graph optimizations
+constructor2 = get_sibling_constructor(NoOptimizations, AzureDownloadableModel, "resnet50_vaiq_int8")
+constructor3 = get_sibling_constructor(NoOptimizations, AzureDownloadableModel, "ResNet50_vaiq")
+register_test(constructor2, "resnet50_vaiq_int8_no_opt")
+register_test(constructor3, "ResNet50_vaiq_no_opt")
+
+# truncated_constructor = get_trucated_constructor(TruncatedModel, AzureDownloadableModel, "ResNet50_vaiq")
+# for n in range(4, 10):
+#     register_test(truncated_constructor(n,""), f"ResNet50_vaiq_trunc_{n}")

--- a/alt_e2eshark/onnx_tests/operators/add.py
+++ b/alt_e2eshark/onnx_tests/operators/add.py
@@ -4,41 +4,21 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from onnx import TensorProto
-import onnx
-from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info
+from onnx.helper import make_node, make_tensor_value_info
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_test
 
-# add a test by setting test_dict["my_test_name"] = OnnxModelInfo(info about test)
-class AddModel(OnnxModelInfo):
-    def construct_model(self):
-        # Create an input (ValueInfoProto)
-        X = make_tensor_value_info("X", TensorProto.FLOAT, [4, 5])
-        Y = make_tensor_value_info("Y", TensorProto.FLOAT, [4, 5])
+class AddModel(BuildAModel):
+    def construct_i_o_value_info(self):
+        self.input_vi = [
+            make_tensor_value_info("X", TensorProto.FLOAT, [4, 5]),
+            make_tensor_value_info("Y", TensorProto.FLOAT, [4, 5]),
+        ]
+        self.output_vi = [make_tensor_value_info("Z", TensorProto.FLOAT, [4, 5])]
 
-        # Create an output
-        Z = make_tensor_value_info("Z", TensorProto.FLOAT, [4, 5])
-
-        # Create a node (NodeProto)
-        addnode = make_node(
-            "Add", ["X", "Y"], ["Z"], "addnode"  # node name  # inputs  # outputs
-        )
-
-        # Create the graph (GraphProto)
-        graph = make_graph(
-            [addnode],
-            "main",
-            [X, Y],
-            [Z],
-        )
-
-        # Create the model (ModelProto)
-        onnx_model = make_model(graph)
-        onnx_model.opset_import[0].version = 19
-
-        onnx.save(onnx_model, self.model)
-
+    def construct_nodes(self):
+        self.node_list.append(make_node("Add", ["X", "Y"], ["Z"], "addnode"))
 
 register_test(AddModel, "add_test")
 

--- a/alt_e2eshark/onnx_tests/operators/concat.py
+++ b/alt_e2eshark/onnx_tests/operators/concat.py
@@ -4,25 +4,23 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import numpy, torch, sys
-import onnxruntime
 from onnx import TensorProto
-import onnx
-from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_tensor
-import os
+from onnx.helper import make_node, make_tensor_value_info
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_test
 
-class ConcatModel(OnnxModelInfo):
-    def construct_model(self):
+class ConcatModel(BuildAModel):
+    def construct_i_o_value_info(self):
         # Create an input (ValueInfoProto)
         X = make_tensor_value_info("X", TensorProto.FLOAT, [1, 4, 5])
         Y = make_tensor_value_info("Y", TensorProto.FLOAT, [2, 4, 5])
-
         # Create an output
         Z = make_tensor_value_info("Z", TensorProto.FLOAT, [3, 4, 5])
+        self.input_vi = [X, Y]
+        self.output_vi = [Z]
 
+    def construct_nodes(self):
         # Create a node (NodeProto)
         concat_node = make_node(
             op_type="Concat",
@@ -30,20 +28,6 @@ class ConcatModel(OnnxModelInfo):
             outputs=["Z"],
             axis=0,
         )
-
-        # Create the graph (GraphProto)
-        graph = make_graph(
-            nodes=[concat_node],
-            name="main",
-            inputs=[X, Y],
-            outputs=[Z],
-        )
-
-        # Create the model (ModelProto)
-        onnx_model = make_model(graph)
-        onnx_model.opset_import[0].version = 19
-
-        onnx.save(onnx_model, self.model)
-
+        self.node_list = [concat_node]
 
 register_test(ConcatModel, "concat_test")

--- a/alt_e2eshark/onnx_tests/operators/conv.py
+++ b/alt_e2eshark/onnx_tests/operators/conv.py
@@ -4,34 +4,34 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from onnx import TensorProto
-import onnx
-from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_tensor
+from onnx.helper import make_tensor_value_info, make_tensor
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_with_name
 
-class QConvModelBase(OnnxModelInfo):
+class QConvModelBase(BuildAModel):
     def __init__(self, specs, *args, **kwargs):
         (self.N, self.Cin, self.Hin, self.Win, self.Cout, self.groups, self.Hker, self.Wker, self.pads, self.dilations, self.strides) = specs
         self.Hout = int((self.Hin + self.pads[0] + self.pads[2] - self.dilations[0]*(self.Hker - 1) - 1)/self.strides[0] + 1)
         self.Wout = int((self.Win + self.pads[1] + self.pads[3] - self.dilations[1]*(self.Wker - 1) - 1)/self.strides[1] + 1)
         super().__init__(*args, **kwargs)
 
-    def construct_model(self):
+    def construct_i_o_value_info(self):
         # float input tensor:
         AX0 = make_tensor_value_info("AX0", TensorProto.FLOAT, [self.N, self.Cin, self.Hin, self.Win])
         # quantized weight tensor inputs
         BK = make_tensor_value_info("BK", TensorProto.INT8, [self.Cout, int(self.Cin/self.groups), self.Hker, self.Wker])
+        self.input_vi = [AX0, BK]
         # output tensor
         X1 = make_tensor_value_info("X1", TensorProto.FLOAT, [self.N, self.Cout, self.Hout, self.Wout])
-        
+        self.output_vi = [X1]
+    
+    def construct_nodes(self):        
         KZPT = make_tensor("ZPT", TensorProto.INT8, [], [0])
         KST = make_tensor("KST", TensorProto.FLOAT, [], [3.125000e-02])
         
-        node_list = []
-        app_node = lambda op_ty, inputs, outputs, **kwargs: node_list.append(
-            make_node(op_ty, inputs, outputs, **kwargs)
-        )
+        app_node = self.get_app_node()
+
         # Quantization Scheme Constants
         app_node("Constant", [], ["KZP"], value=KZPT)
         app_node("Constant", [], ["KS"], value=KST)
@@ -45,17 +45,6 @@ class QConvModelBase(OnnxModelInfo):
             strides=self.strides,
         )
 
-        graph = make_graph(
-            node_list,
-            "main",
-            [AX0, BK],
-            [X1],
-        )
-
-        onnx_model = make_model(graph)
-        onnx_model.opset_import[0].version = 19
-
-        onnx.save(onnx_model, self.model)
 
 N = 2
 Cin = 3

--- a/alt_e2eshark/onnx_tests/operators/dynamic_quantize_linear.py
+++ b/alt_e2eshark/onnx_tests/operators/dynamic_quantize_linear.py
@@ -7,42 +7,27 @@ from onnx import TensorProto
 import onnx
 from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_test
 
 
 
-class DynamicQuantizeLinearModel(OnnxModelInfo):
-    def construct_model(self):
-        input_X = make_tensor_value_info("X", TensorProto.FLOAT, [3, 4])
-        output_Z = make_tensor_value_info("Z", TensorProto.UINT8, [3, 4])
-        output_S = make_tensor_value_info("scale", TensorProto.FLOAT, [])
-        output_P = make_tensor_value_info("zp", TensorProto.UINT8, [])
+class DynamicQuantizeLinearModel(BuildAModel):
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X", TensorProto.FLOAT, [3, 4])]
+        self.output_vi = [
+            make_tensor_value_info("Z", TensorProto.UINT8, [3, 4]),
+            make_tensor_value_info("scale", TensorProto.FLOAT, []),
+            make_tensor_value_info("zp", TensorProto.UINT8, []),
+        ]
 
+    def construct_nodes(self):
         # Create a 'DQL' node (NodeProto)
-        DQL_node = make_node(
+        self.node_list = [make_node(
             "DynamicQuantizeLinear",
             ["X"],
             ["Z", "scale", "zp"],
             "DQL_node",  # op_type  # inputs  # outputs  # node name
-        )
-
-        # Create the graph (GraphProto)
-        graph = make_graph(
-            [DQL_node],  # Nodes in the graph
-            "main",  # Name of the graph
-            [input_X],  # Inputs to the graph
-            [output_Z, output_S, output_P],  # Outputs of the graph
-        )
-
-        # Create the model (ModelProto)
-        onnx_model = make_model(graph)
-        onnx_model.opset_import[0].version = (
-            11  # Set the opset version to ensure compatibility
-        )
-
-        # Save the model
-        onnx.save(onnx_model, self.model)
-
+        )]
 
 register_test(DynamicQuantizeLinearModel, "dynamic_quanitze_linear_test")

--- a/alt_e2eshark/onnx_tests/operators/pad.py
+++ b/alt_e2eshark/onnx_tests/operators/pad.py
@@ -3,41 +3,33 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import numpy, torch, sys
-import onnxruntime
 from onnx import TensorProto
-import onnx
-from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_tensor
-import os
+from onnx.helper import make_tensor_value_info
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_test
 
 
-class PadModel(OnnxModelInfo):
+class PadModel(BuildAModel):
     def construct_model(self):
+        app_node = self.get_app_node()
+        app_node("Constant", [], ["XP"], value_ints=[2,1,3,4])
+        app_node("Pad", ["X","XP","XV"], ["XO"])
+        app_node("Pad", ["Y","XP","YV"], ["YO"])
+        app_node("Constant", [], ["ZP"], value_ints=[0,0,2,1,0,0,4,3])
+        app_node("Pad", ["Z","ZP"], ["ZO"], mode="edge")
+    
+    def construct_i_o_value_info(self):
         X = make_tensor_value_info("X", TensorProto.FLOAT, [4, 5])
         Y = make_tensor_value_info("Y", TensorProto.INT32, [4, 5])
         Z = make_tensor_value_info("Z", TensorProto.FLOAT, [1, 1, 4, 5])
-        W = make_tensor_value_info("W", TensorProto.FLOAT, [3, 4, 5])
-        XP = make_tensor_value_info("XP", TensorProto.INT64, [4])
         XV = make_tensor_value_info("XV", TensorProto.FLOAT, [])
         YV = make_tensor_value_info("YV", TensorProto.INT32, [])
-        ZP = make_tensor_value_info("ZP", TensorProto.INT64, [8])
 
         XO = make_tensor_value_info("XO", TensorProto.FLOAT, [-1, -1])
         YO = make_tensor_value_info("YO", TensorProto.INT32, [-1, -1])
         ZO = make_tensor_value_info("ZO", TensorProto.FLOAT, [-1, -1, -1, -1])
-        # constantNode = make_node(op_type="Constant", inputs=[], outputs=["XP"], value_ints=[2,1,3,4])
-        # padnodeX = make_node("Pad", ["X","XP","XV"], ["XO"])
-        # padnodeY = make_node(op_type="Pad", inputs=["Y","XP","YV"], outputs=["YO"])
-        constantNodeZ = make_node(op_type="Constant", inputs=[], outputs=["ZP"], value_ints=[0,0,2,1,0,0,4,3])
-        padnodeZ = make_node(op_type="Pad", inputs=["Z","ZP"], outputs=["ZO"], mode="edge")
-        # padgraph = make_graph([constantNode, padnodeX], "main", [X, XV], [XO])
-        padgraph = make_graph([constantNodeZ, padnodeZ], "main", [Z], [ZO])
-        onnx_model = make_model(padgraph)
-        onnx_model.opset_import[0].version = 19
-
-        onnx.save(onnx_model, self.model)
+        self.input_vi = [X, XV, Y, YV, Z]
+        self.output_vi = [XO, YO, ZO]
 
 register_test(PadModel, "pad_test")

--- a/alt_e2eshark/onnx_tests/operators/resize.py
+++ b/alt_e2eshark/onnx_tests/operators/resize.py
@@ -4,38 +4,29 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from onnx import TensorProto
-import onnx
-from onnx.helper import make_model, make_node, make_graph, make_tensor_value_info, make_tensor
+from onnx.helper import make_tensor_value_info, make_tensor
 
-from e2e_testing.framework import OnnxModelInfo
+from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_test
 
 
-class ResizeModel(OnnxModelInfo):
-    def construct_model(self):
-        X = make_tensor_value_info("X", TensorProto.FLOAT, [1,21,65,65])
-        Y = make_tensor_value_info("Y", TensorProto.FLOAT, [1, 21, 513, 513])
+class ResizeModel(BuildAModel):
+    def construct_i_o_value_info(self):
+        self.input_vi = [make_tensor_value_info("X", TensorProto.FLOAT, [1,21,65,65])]
+        self.output_vi = [make_tensor_value_info("Y", TensorProto.FLOAT, [1, 21, 513, 513])]
+    
+    def construct_nodes(self):
         C0T = make_tensor("C0T",TensorProto.FLOAT, [4], [1.000000e+00, 1.000000e+00, 7.89230776, 7.89230776])
         C1T = make_tensor("C1T",TensorProto.FLOAT, [8], [0.000000e+00, 0.000000e+00, 0.000000e+00, 0.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00, 1.000000e+00])
+        app_node = self.get_app_node()
+        app_node("Constant", [], ["C0"], value=C0T)
+        app_node("Constant", [], ["C1"], value=C1T)
 
-        const_node0 = make_node(
-            op_type="Constant",
-            inputs=[],
-            outputs=["C0"],
-            value=C0T,
-        )
-
-        const_node1 = make_node(
-            op_type="Constant",
-            inputs=[],
-            outputs=["C1"],
-            value=C1T,
-        )
-
-        resize_node = make_node(
-            op_type="Resize",
-            inputs=["X","C1","C0"],
-            outputs=["Y"],
+        # this node has a lot of redundant info. Testing to see how it is treated.
+        app_node(
+            "Resize",
+            ["X","C1","C0"],
+            ["Y"],
             mode="linear",
             exclude_outside=0,
             coordinate_transformation_mode="half_pixel",
@@ -43,10 +34,5 @@ class ResizeModel(OnnxModelInfo):
             extrapolation_value=0.0,
             nearest_mode="round_prefer_floor",
         )
-
-        graph = make_graph([const_node0, const_node1, resize_node],"main",[X],[Y])
-        onnx_model = make_model(graph)
-        onnx_model.opset_import[0].version = 19
-        onnx.save(onnx_model, self.model)
 
 register_test(ResizeModel, "resize_test")


### PR DESCRIPTION
1. Adds a new file: `alt_e2eshark/onnx_tests/helper_classes.py`
2. Adds a base class for user-generated onnx models called `MakeAModel`. All that needs to be overridden are the methods `construct_nodes` and `construct_i_o_value_info`. See the many examples/docstrings for more details.
3. Adds a base class for truncating an onnx graph (i.e., to return an earlier node output) called `TruncatedModel`.
4. Moves `AzureDownloadableModel` to `helper_classes.py`
5. Adds the ability to modify the `onnxruntime.SessionOptions()`, through the overridable method `update_sess_options`, on a test-by-test-basis to disable optimizations which might cause the gold output to lose accuracy. E.g., quantized resize/ Gemm in ort CPU provider seems to cause a loss in numerical accuracy. With models like resnet and deeplab, this change is the difference between terrible numerics mismatch and a pass.
6. Adds a few tests to either showcase some helper classes, or to introduce more examples from the public storage so users don't need private access to run important examples.