### PR TITLE
add --cleanup flag for cleaning up files after each test.

### DIFF
--- a/alt_e2eshark/e2e_testing/logging_utils.py
+++ b/alt_e2eshark/e2e_testing/logging_utils.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+from pathlib import Path
+import traceback
+import shutil
+from e2e_testing.framework import result_comparison
+
+
+def log_result(result, log_dir, tol):
+    # TODO: add more information for the result comparison (e.g., on verbose, add information on where the error is occuring, etc)
+    summary = result_comparison(result, tol)
+    num_match = 0
+    num_total = 0
+    for s in summary:
+        num_match += s.sum().item()
+        num_total += s.nelement()
+    percent_correct = num_match / num_total
+    with open(log_dir + "inference_comparison.log", "w+") as f:
+        f.write(
+            f"matching values with (rtol,atol) = {tol}: {num_match} of {num_total} = {percent_correct*100}%\n"
+        )
+        f.write(f"Test Result:\n{result}")
+    return num_match == num_total
+
+
+def log_exception(e: Exception, path: str, stage: str, name: str, verbose: bool):
+    """generates a log for an exception generated during a testing stage"""
+    log_filename = path + stage + ".log"
+    base_str = f"Failed test at stage {stage} with exception:\n{e}\n"
+    with open(log_filename, "w") as f:
+        f.write(base_str)
+        if verbose:
+            print(f"\tFAILED ({stage})" + " " * 20)
+            traceback.print_exception(e, file=f)
+        else:
+            print(f"FAILED: {name}")
+
+
+def scan_dir_del_if_large(dir, size_MB):
+    remove_files = []
+    for root, dirs, files in os.walk(dir):
+        for name in files:
+            curr_file = os.path.join(root, name)
+            size_bytes = os.path.getsize(curr_file)
+            if size_bytes >= size_MB * (10**6):
+                remove_files.append(curr_file)
+    for file in remove_files:
+        os.remove(file)
+    return remove_files
+
+
+def scan_dir_del_mlir_vmfb(dir):
+    removed_files = []
+    for root, dirs, files in os.walk(dir):
+        for name in files:
+            curr_file = os.path.join(root, name)
+            if name.endswith(".mlir") or name.endswith(".vmfb"):
+                removed_files.append(curr_file)
+    for file in removed_files:
+        os.remove(file)
+    return removed_files
+
+
+def post_test_clean(log_dir, cleanup, verbose):
+    match cleanup:
+        case 0:
+            return
+        case 1:
+            files = scan_dir_del_if_large(log_dir, 500)
+        case 2:
+            files = scan_dir_del_mlir_vmfb(log_dir)
+        case 3:
+            shutil.rmtree(Path(log_dir))
+    # if verbose:
+    #     print(f"cleanup level {cleanup} removed: ", end="")
+    #     for f in files:
+    #         print(Path(f).name, end=", ")
+    #     print("")

--- a/alt_e2eshark/e2e_testing/logging_utils.py
+++ b/alt_e2eshark/e2e_testing/logging_utils.py
@@ -65,6 +65,16 @@ def scan_dir_del_mlir_vmfb(dir):
         os.remove(file)
     return removed_files
 
+def scan_dir_del_not_logs(dir):
+    removed_files = []
+    for root, dirs, files in os.walk(dir):
+        for name in files:
+            curr_file = os.path.join(root, name)
+            if not name.endswith(".log"):
+                removed_files.append(curr_file)
+    for file in removed_files:
+        os.remove(file)
+    return removed_files
 
 def post_test_clean(log_dir, cleanup, verbose):
     match cleanup:
@@ -75,6 +85,8 @@ def post_test_clean(log_dir, cleanup, verbose):
         case 2:
             files = scan_dir_del_mlir_vmfb(log_dir)
         case 3:
+            files = scan_dir_del_not_logs(log_dir)
+        case 4:
             shutil.rmtree(Path(log_dir))
     # if verbose:
     #     print(f"cleanup level {cleanup} removed: ", end="")

--- a/alt_e2eshark/e2e_testing/logging_utils.py
+++ b/alt_e2eshark/e2e_testing/logging_utils.py
@@ -65,6 +65,7 @@ def scan_dir_del_mlir_vmfb(dir):
         os.remove(file)
     return removed_files
 
+
 def scan_dir_del_not_logs(dir):
     removed_files = []
     for root, dirs, files in os.walk(dir):
@@ -75,6 +76,7 @@ def scan_dir_del_not_logs(dir):
     for file in removed_files:
         os.remove(file)
     return removed_files
+
 
 def post_test_clean(log_dir, cleanup, verbose):
     match cleanup:
@@ -88,8 +90,3 @@ def post_test_clean(log_dir, cleanup, verbose):
             files = scan_dir_del_not_logs(log_dir)
         case 4:
             shutil.rmtree(Path(log_dir))
-    # if verbose:
-    #     print(f"cleanup level {cleanup} removed: ", end="")
-    #     for f in files:
-    #         print(Path(f).name, end=", ")
-    #     print("")

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -10,7 +10,6 @@ import warnings
 from pathlib import Path
 import argparse
 import re
-import logging
 from typing import List, Literal, Optional
 
 # append alt_e2eshark dir to path to allow importing without explicit pythonpath management
@@ -18,6 +17,7 @@ TEST_DIR = str(Path(__file__).parent)
 sys.path.append(TEST_DIR)
 
 from e2e_testing.framework import *
+from e2e_testing.logging_utils import log_exception, log_result, post_test_clean
 
 # import frontend test configs:
 from e2e_testing.test_configs.onnxconfig import (
@@ -118,7 +118,8 @@ def main(args):
         args.no_artifacts,
         args.verbose,
         stages,
-        args.load_inputs
+        args.load_inputs,
+        int(args.cleanup),
     )
 
     if args.report:
@@ -128,7 +129,7 @@ def main(args):
 
 
 def run_tests(
-    test_list: List[Test], config: TestConfig, parent_log_dir: str, no_artifacts: bool, verbose: bool, stages: List[str], load_inputs: bool
+    test_list: List[Test], config: TestConfig, parent_log_dir: str, no_artifacts: bool, verbose: bool, stages: List[str], load_inputs: bool, cleanup: int,
 ) -> Dict[str, str]:
     """runs tests in test_list based on config. Returns a dictionary containing the test statuses."""
     # TODO: multi-process
@@ -239,6 +240,7 @@ def run_tests(
         except Exception as e:
             status_dict[t.unique_name] = curr_stage
             log_exception(e, log_dir, curr_stage, t.unique_name, verbose)
+            post_test_clean(log_dir, cleanup, verbose)
             continue
 
         # store the results
@@ -269,6 +271,9 @@ def run_tests(
                 print(f"\tPASSED" + " "*30)
             else:
                 print(f"\tFAILED ({status_dict[t.unique_name]})" + " "*20)
+        
+        # test is complete, perform cleanup
+        post_test_clean(log_dir,  cleanup, verbose)
 
     num_passes = list(status_dict.values()).count("PASS")
     print("\nTest Summary:")
@@ -276,38 +281,6 @@ def run_tests(
     print(f"results stored in {parent_log_dir}")
     status_dict = dict(sorted(status_dict.items(), key=lambda item : item[0].lower()))
     return status_dict
-
-
-def log_result(result, log_dir, tol):
-    # TODO: add more information for the result comparison (e.g., on verbose, add information on where the error is occuring, etc)
-    summary = result_comparison(result, tol)
-    num_match = 0
-    num_total = 0
-    for s in summary:
-        num_match += s.sum().item()
-        num_total += s.nelement()
-    percent_correct = num_match / num_total
-    with open(log_dir + "inference_comparison.log", "w+") as f:
-        f.write(
-            f"matching values with (rtol,atol) = {tol}: {num_match} of {num_total} = {percent_correct*100}%\n"
-        )
-        f.write(f"Test Result:\n{result}")
-    return num_match == num_total
-
-
-def log_exception(e: Exception, path: str, stage: str, name: str, verbose: bool):
-    '''generates a log for an exception generated during a testing stage'''
-    log_filename = path + stage + ".log"
-    base_str = f"Failed test at stage {stage} with exception:\n{e}\n"
-    with open(log_filename, "w") as f:
-        f.write(base_str)
-        if verbose:
-            print(f"\tFAILED ({stage})" + " "*20)
-            import traceback
-            traceback.print_exception(e, file=f)
-        else:
-            print(f"FAILED: {name}")
-
 
 def _get_argparse():
     msg = "The run.py script to run e2e shark tests"
@@ -426,6 +399,12 @@ def _get_argparse():
         help="If enabled, this flag will prevent saving mlir and vmfb files",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--cleanup",
+        help="Specify cleanup level: 0 (nothing deleted), 1 (files > 500MB), 2 (.mlir, .vmfb), 3 (everything)",
+        choices=['0','1','2','3'],
+        default='0',
     )
     parser.add_argument(
         "--report",

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -402,8 +402,8 @@ def _get_argparse():
     )
     parser.add_argument(
         "--cleanup",
-        help="Specify cleanup level: 0 (nothing deleted), 1 (files > 500MB), 2 (.mlir, .vmfb), 3 (everything)",
-        choices=['0','1','2','3'],
+        help="Specify cleanup level: 0 (nothing), 1 (size >= 500M), 2 (.mlir and .vmfb), 3 (all but .log), 4 (everything)",
+        choices=['0','1','2','3','4'],
         default='0',
     )
     parser.add_argument(


### PR DESCRIPTION
Levels are:

0 (default) cleans nothing
1 removes files larger or equal to 500M
2 removes all .vmfb and .mlir files
3 removes all but .log files
4 removes all files

Sample usage:
```
python run.py --cleanup=2 <other-args>
```
This would delete .mlir and .vmfb files after each test.

Other changes introduced: new file `e2e_testing/logging_utils.py` for storing misc functions used for `log_dir` management in `run.py` script. 