### PR TITLE
[alt] add a benchmark stage

### DIFF
--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -157,7 +157,7 @@ class TestConfig(abc.ABC):
         """runs the input through the compiled artifact"""
         pass
 
-    def benchmark(self, artifact: CompiledOutput, input: TestTensors, *, func_name=None) -> float:
+    def benchmark(self, artifact: CompiledOutput, input: TestTensors, repetitions: int, *, func_name=None) -> float:
         """returns a float representing inference time in ms"""
         pass
 

--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -157,6 +157,9 @@ class TestConfig(abc.ABC):
         """runs the input through the compiled artifact"""
         pass
 
+    def benchmark(self, artifact: CompiledOutput, input: TestTensors, *, func_name=None) -> float:
+        """returns a float representing inference time in ms"""
+        pass
 
 class Test(NamedTuple):
     """Used to store the name and TestInfo constructor for a registered test"""

--- a/alt_e2eshark/e2e_testing/logging_utils.py
+++ b/alt_e2eshark/e2e_testing/logging_utils.py
@@ -71,7 +71,7 @@ def scan_dir_del_not_logs(dir):
     for root, dirs, files in os.walk(dir):
         for name in files:
             curr_file = os.path.join(root, name)
-            if not name.endswith(".log"):
+            if not name.endswith(".log") and name != "benchmark.json":
                 removed_files.append(curr_file)
     for file in removed_files:
         os.remove(file)

--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -232,7 +232,7 @@ class CLOnnxTestConfig(TestConfig):
                 raise FileNotFoundError(error_msg)
         return TestTensors.load_from(self.tensor_info_dict[test_name][0], self.tensor_info_dict[test_name][1], run_dir, "output")
 
-    def benchmark(self, artifact: str, inputs: TestTensors, *, func_name=None) -> float:
+    def benchmark(self, artifact: str, inputs: TestTensors, repetitions: int = 5, *, func_name=None) -> float:
         run_dir = Path(artifact).parent
         detail_log = run_dir.joinpath("detail", "benchmark.detail.log")
         commands_log = run_dir.joinpath("commands", "benchmark.commands.log")
@@ -240,7 +240,7 @@ class CLOnnxTestConfig(TestConfig):
         func = self.backend.load(artifact,func_name=func_name)
         script = func(inputs)
         benchmark_script = "iree-benchmark-module " + script[15:]
-        benchmark_script += f" --benchmark_repetitions=10 --device_allocator=caching --benchmark_out='{report_json}' --benchmark_out_format=json 1> {detail_log} 2>&1"
+        benchmark_script += f" --benchmark_repetitions={repetitions} --device_allocator=caching --benchmark_out='{report_json}' --benchmark_out_format=json 1> {detail_log} 2>&1"
         with open(commands_log, "w") as file:
             file.write(benchmark_script)
         Path(report_json).unlink(missing_ok=True)

--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -15,6 +15,7 @@ from typing import Tuple, Any
 from onnxruntime import InferenceSession
 import os
 from pathlib import Path
+import json
 
 REDUCE_TO_LINALG_PIPELINE = [
     "torch-lower-to-backend-contract",
@@ -231,3 +232,27 @@ class CLOnnxTestConfig(TestConfig):
                 raise FileNotFoundError(error_msg)
         return TestTensors.load_from(self.tensor_info_dict[test_name][0], self.tensor_info_dict[test_name][1], run_dir, "output")
 
+    def benchmark(self, artifact: str, inputs: TestTensors, *, func_name=None) -> float:
+        run_dir = Path(artifact).parent
+        detail_log = run_dir.joinpath("detail", "benchmark.detail.log")
+        commands_log = run_dir.joinpath("commands", "benchmark.commands.log")
+        report_json = run_dir.joinpath("detail", "benchmark.json")
+        func = self.backend.load(artifact,func_name=func_name)
+        script = func(inputs)
+        benchmark_script = "iree-benchmark-module " + script[15:]
+        benchmark_script += f" --benchmark_repetitions=10 --device_allocator=caching --benchmark_out='{report_json}' --benchmark_out_format=json 1> {detail_log} 2>&1"
+        with open(commands_log, "w") as file:
+            file.write(benchmark_script)
+        Path(report_json).unlink(missing_ok=True)
+        os.system(benchmark_script)
+        if not os.path.exists(report_json):
+            error_msg = f"failure executing command: \n{benchmark_script}\n failed to produce output file {report_json}.\n"
+            error_msg += f"Error detail in '{detail_log}'"
+            raise FileNotFoundError(error_msg)
+        with open(report_json) as contents:
+            loaded_dict = json.load(contents) 
+        mean_stats = loaded_dict["benchmarks"][-4]
+        if mean_stats["name"] != "BM_main/process_time/real_time_mean":
+            raise ValueError("Name of benchmark item is unexpected")
+        time = mean_stats["real_time"]
+        return time

--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -252,7 +252,7 @@ class CLOnnxTestConfig(TestConfig):
         with open(report_json) as contents:
             loaded_dict = json.load(contents) 
         mean_stats = loaded_dict["benchmarks"][-4]
-        if mean_stats["name"] != "BM_main/process_time/real_time_mean":
+        if mean_stats["name"] != f"BM_{func_name}/process_time/real_time_mean":
             raise ValueError("Name of benchmark item is unexpected")
         time = mean_stats["real_time"]
         return time

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -244,7 +244,8 @@ def run_tests(
             curr_stage = "benchmark"
             if curr_stage in stages:
                 notify_stage()
-                mean_time_ms = config.benchmark(compiled_artifact, inputs, func_name=func_name)
+                # TODO: make repetitions configurable from a command line arg
+                mean_time_ms = config.benchmark(compiled_artifact, inputs, repetitions=5, func_name=func_name)
 
             # apply model-specific post-processing:
             curr_stage = "postprocessing"
@@ -288,8 +289,6 @@ def run_tests(
                 print(f"\tPASSED" + " "*30)
             else:
                 print(f"\tFAILED ({status_dict[t.unique_name]['exit_status']})" + " "*20)
-            if mean_time_ms:
-                print(f"mean_inference_time = {mean_time_ms} ms")
 
     num_passes = [v["exit_status"] for v in status_dict.values()].count("PASS")
     print("\nTest Summary:")

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -246,7 +246,7 @@ def run_tests(
             if curr_stage in stages:
                 notify_stage()
                 # TODO: make repetitions configurable from a command line arg
-                mean_time_ms = config.benchmark(compiled_artifact, inputs, repetitions=5, func_name=func_name)
+                mean_time_ms = config.benchmark(compiled_artifact, inputs, repetitions=3, func_name=func_name)
 
             # apply model-specific post-processing:
             curr_stage = "postprocessing"

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -40,6 +40,7 @@ ALL_STAGES = [
     "construct_inputs",
     "native_inference",
     "compiled_inference",
+    "benchmark",
     "postprocessing",
 ]
 
@@ -227,6 +228,13 @@ def run_tests(
                 outputs_raw = config.run(compiled_artifact, inputs, func_name=func_name)
                 outputs_raw.save_to(log_dir + "output")
 
+            # benchmark inference time with compiled module
+            mean_time_ms = None
+            curr_stage = "benchmark"
+            if curr_stage in stages:
+                notify_stage()
+                mean_time_ms = config.benchmark(compiled_artifact, inputs, func_name=func_name)
+
             # apply model-specific post-processing:
             curr_stage = "postprocessing"
             if curr_stage in stages:
@@ -269,6 +277,8 @@ def run_tests(
                 print(f"\tPASSED" + " "*30)
             else:
                 print(f"\tFAILED ({status_dict[t.unique_name]})" + " "*20)
+            if mean_time_ms:
+                print(f"mean_inference_time = {mean_time_ms} ms")
 
     num_passes = list(status_dict.values()).count("PASS")
     print("\nTest Summary:")

--- a/alt_e2eshark/utils/report.py
+++ b/alt_e2eshark/utils/report.py
@@ -21,7 +21,7 @@ def generate_report(args, stages, status_dict):
     stages.reverse()
     counts = {s : 0 for s in stages}
     for (key, value) in status_dict.items():
-        counts[value] += 1
+        counts[value["exit_status"]] += 1
     results_str = "## Summary\n\n|Stage|Count|\n|--|--|\n"
     results_str += f"| Total | {len(status_dict.keys())} |\n"
     for (key, value) in counts.items():
@@ -29,10 +29,10 @@ def generate_report(args, stages, status_dict):
 
     # set up report detail
     report_string = f"\n## Test Run Detail \nTest was run with the following arguments:\n{args}\n\n"
-    report_string += "| Test | Exit Status | Notes |\n"
-    report_string += "|--|--|--|\n"
+    report_string += "| Test | Exit Status | Mean Benchmark Time (ms) | Notes |\n"
+    report_string += "|--|--|--|--|\n"
     for (key, value) in status_dict.items():
-        report_string += f"| {key} | {value} | |\n"
+        report_string += f"| {key} | {value['exit_status']} | {value['time_ms']} | |\n"
 
     # get a report file and write to it 
     with open(args.report_file, "w") as file:


### PR DESCRIPTION
1. adds a stage "benchmark" which is not included by default
2. implements benchmarking for mode = cl-onnx-iree
3. adds benchmark time to generated reports
4. adds a run.py command line arg `--benchmark` for convenience. 

Sample usage:

```
python run.py -m cl-onnx-iree --benchmark -t migraphx -v --report
```

generates:


## Summary

|Stage|Count|
|--|--|
| Total | 30 |
| PASS | 12 |
| Numerics | 4 |
| results-summary | 0 |
| postprocessing | 0 |
| benchmark | 0 |
| compiled_inference | 2 |
| native_inference | 2 |
| construct_inputs | 0 |
| compilation | 7 |
| preprocessing | 0 |
| import_model | 3 |
| setup | 0 |

## Test Run Detail 
Test was run with the following arguments:
Namespace(device='local-task', backend='llvm-cpu', iree_compile_args=None, mode='cl-onnx-iree', torchtolinalg=False, stages=None, skip_stages=None, benchmark=True, load_inputs=False, groups='all', test_filter='migraphx', testsfile=None, tolerance=None, verbose=True, rundirectory='test-run', no_artifacts=False, report=True, report_file='report.md')

| Test | Exit Status | Mean Benchmark Time (ms) | Notes |
|--|--|--|--|
| migraphx_agentmodel__AgentModel | compilation | None | |
| migraphx_bert__bert-large-uncased | compilation | None | |
| migraphx_bert__bertsquad-12 | compilation | None | |
| migraphx_cadene__dpn92i1 | PASS | 527.7663788991049 | |
| migraphx_cadene__inceptionv4i16 | PASS | 25202.195480884984 | |
| migraphx_cadene__resnext101_64x4di1 | PASS | 1144.4547850056551 | |
| migraphx_cadene__resnext101_64x4di16 | PASS | 11430.92905820231 | |
| migraphx_huggingface-transformers__bert_mrpc8 | native_inference | None | |
| migraphx_mlperf__bert_large_mlperf | Numerics | 9947.680042800494 | |
| migraphx_mlperf__resnet50_v1 | PASS | 320.7237229478779 | |
| migraphx_models__whisper-tiny-decoder | compiled_inference | None | |
| migraphx_models__whisper-tiny-encoder | native_inference | None | |
| migraphx_onnx-misc__taau_low_res_downsample_d2s_for_infer_time_fp16_opset11 | import_model | None | |
| migraphx_onnx-model-zoo__gpt2-10 | compilation | None | |
| migraphx_ORT__bert_base_cased_1 | PASS | 1057.2638947051018 | |
| migraphx_ORT__bert_base_uncased_1 | compilation | None | |
| migraphx_ORT__bert_large_uncased_1 | PASS | 3485.4127474012785 | |
| migraphx_ORT__distilgpt2_1 | compiled_inference | None | |
| migraphx_ORT__onnx_models__bert_base_cased_1_fp16_gpu | Numerics | 3408.8035288092215 | |
| migraphx_ORT__onnx_models__bert_large_uncased_1_fp16_gpu | Numerics | 11613.216011907207 | |
| migraphx_ORT__onnx_models__distilgpt2_1_fp16_gpu | Numerics | 171.46043484826805 | |
| migraphx_pytorch-examples__wlang_gru | compilation | None | |
| migraphx_pytorch-examples__wlang_lstm | compilation | None | |
| migraphx_sd__unet__model | import_model | None | |
| migraphx_sdxl__unet__model | import_model | None | |
| migraphx_torchvision__densenet121i32 | PASS | 4118.973942403682 | |
| migraphx_torchvision__inceptioni1 | PASS | 718.8349567120895 | |
| migraphx_torchvision__inceptioni32 | PASS | 23589.06321739778 | |
| migraphx_torchvision__resnet50i1 | PASS | 312.4926148477243 | |
| migraphx_torchvision__resnet50i64 | PASS | 14743.020548688946 | |
