### PR TITLE
[alt] adds a numerics failure reproducer

### DIFF
--- a/alt_e2eshark/onnx_tests/operators/conv.py
+++ b/alt_e2eshark/onnx_tests/operators/conv.py
@@ -5,9 +5,25 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from onnx import TensorProto
 from onnx.helper import make_tensor_value_info, make_tensor
+import numpy
 
 from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_with_name, register_test
+
+class ConvRepro(BuildAModel):
+    def construct_i_o_value_info(self):
+        self.input_vi = [
+            make_tensor_value_info("X", TensorProto.FLOAT, [1,256,112,112]),
+            make_tensor_value_info("W", TensorProto.FLOAT, [256,1,3,3]),
+            make_tensor_value_info("B", TensorProto.FLOAT, [256]),
+            ]
+        self.output_vi = [make_tensor_value_info("Y", TensorProto.FLOAT, [1,256,56,56])]
+    
+    def construct_nodes(self):
+        app_node = self.get_app_node()
+        app_node("Conv",["X","W","B"],["Y"],group=256,kernel_shape=[3,3],pads=[1,1,1,1],strides=[2,2])
+
+register_test(ConvRepro, "conv_depthwise_stride_2")
 
 class QConvModelBase(BuildAModel):
     def __init__(self, specs, *args, **kwargs):

--- a/alt_e2eshark/onnx_tests/operators/conv.py
+++ b/alt_e2eshark/onnx_tests/operators/conv.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from onnx import TensorProto
 from onnx.helper import make_tensor_value_info, make_tensor
-import numpy
 
 from ..helper_classes import BuildAModel
 from e2e_testing.registry import register_with_name, register_test


### PR DESCRIPTION
This particular Conv op signature was found to be causing numerics failures in a few models. E.g.,  "maxvit_rmlp_base_rw_224.sw_in12k"