### PR TITLE
[alt] generate better report summaries

### DIFF
--- a/alt_e2eshark/utils/report.py
+++ b/alt_e2eshark/utils/report.py
@@ -23,7 +23,7 @@ STAGE_SIMPLIFICATION = {
     "construct_inputs": "Gold Inference",
     "native_inference": "Gold Inference",
     "compiled_inference": "IREE Inference Invocation",
-    "postprocessiong": "Inference Comparison",
+    "postprocessing": "Inference Comparison",
     "results-summary": "Inference Comparison",
     "Numerics": "Inference Comparison",
 }

--- a/alt_e2eshark/utils/report.py
+++ b/alt_e2eshark/utils/report.py
@@ -5,36 +5,131 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import json
 import io
+from typing import List, Dict
 
-def save_dict(status_dict, status_dict_json):
+SUMMARY_STAGES = [
+    "Setup",
+    "IREE Compilation",
+    "Gold Inference",
+    "IREE Inference Invocation",
+    "Inference Comparison",
+]
+
+STAGE_SIMPLIFICATION = {
+    "setup": "Setup",
+    "import_model": "IREE Compilation",
+    "preprocessing": "IREE Compilation",
+    "compilation": "IREE Compilation",
+    "construct_inputs": "Gold Inference",
+    "native_inference": "Gold Inference",
+    "compiled_inference": "IREE Inference Invocation",
+    "postprocessiong": "Inference Comparison",
+    "results-summary": "Inference Comparison",
+    "Numerics": "Inference Comparison",
+}
+
+
+def save_dict(status_dict: Dict[str, Dict], status_dict_json: str):
     with io.open(status_dict_json, "w", encoding="utf8") as outfile:
-        dict_str = json.dumps(status_dict, indent=4, sort_keys=True, separators=(',',': '), ensure_ascii=False)
+        dict_str = json.dumps(
+            status_dict,
+            indent=4,
+            sort_keys=True,
+            separators=(",", ": "),
+            ensure_ascii=False,
+        )
         outfile.write(dict_str)
 
-def generate_report(args, stages, status_dict):
+
+def get_exit_status_counts(
+    stages: List, status_dict: Dict[str, Dict], simplify: bool
+) -> Dict[str, int]:
+    use_stages = SUMMARY_STAGES if simplify else stages
+    counts = {s: 0 for s in use_stages}
+    for key, value in status_dict.items():
+        if value["exit_status"] == "PASS":
+            continue
+        stage_name = (
+            STAGE_SIMPLIFICATION[value["exit_status"]]
+            if simplify
+            else value["exit_status"]
+        )
+        counts[stage_name] += 1
+    return counts
+
+
+def get_stage_pass_counts(exit_counts: Dict[str, int], total: int) -> Dict[str, int]:
+    counts = dict()
+    running_total = total
+    for key, value in exit_counts.items():
+        if key == "PASS":
+            continue
+        running_total -= value
+        counts[key] = running_total
+    return counts
+
+
+def get_exit_status_string(counts: Dict[str, int], total) -> str:
+    results_str = "## Fail Summary\n\n"
+    results_str += f"**TOTAL TESTS = {total}**\n"
+    results_str += f"|Stage|# Failed at Stage|% of Total|\n|--|--|--|\n"
+    for key, value in counts.items():
+        if key == "PASS":
+            continue
+        results_str += f"| {key} | {value} | {round((value/total)*100, 1)}% |\n"
+    return results_str
+
+
+def get_stage_pass_string(counts: Dict[str, int], total: int) -> str:
+    results_str = f"## Passing Summary\n\n"
+    results_str += f"**TOTAL TESTS = {total}**\n"
+    results_str += f"|Stage|# Passing|% of Total|% of Attempted|\n|--|--|--|--|\n"
+    running_val = total
+    for key, value in counts.items():
+        if key == "Inference Comparison":
+            key = "Inference Comparison (PASS)"
+        results_str += f"| {key} | {value} | {round((value/total)*100, 1)}% | {round((value/running_val)*100, 1)}% |\n"
+        running_val = value
+    return results_str
+
+
+def get_detail_string(status_dict: Dict[str, Dict]) -> str:
+    report_string = "| Test | Exit Status | Mean Benchmark Time (ms) | Notes |\n"
+    report_string += "|--|--|--|--|\n"
+    for key, value in status_dict.items():
+        report_string += f"| {key} | {value['exit_status']} | {value['time_ms']} | |\n"
+    return report_string
+
+
+def generate_report(
+    args, og_stages: List, status_dict: Dict[str, Dict], *, simplify: bool = True
+):
     """generates a markdown report for a test-run"""
 
-    # set up report summary
+    # add non-stage exit statuses:
+    stages = og_stages
     stages.append("results-summary")
     stages.append("Numerics")
-    stages.append("PASS")
-    stages.reverse()
-    counts = {s : 0 for s in stages}
-    for (key, value) in status_dict.items():
-        counts[value["exit_status"]] += 1
-    results_str = "## Summary\n\n|Stage|Count|\n|--|--|\n"
-    results_str += f"| Total | {len(status_dict.keys())} |\n"
-    for (key, value) in counts.items():
-        results_str += f"| {key} | {value} |\n"
+
+    # get some counts
+    exit_counts = get_exit_status_counts(stages, status_dict, simplify=simplify)
+    total = len(status_dict.keys())
+    pass_counts = get_stage_pass_counts(exit_counts, total)
+
+    # generate report summary strings
+    results_str = get_stage_pass_string(pass_counts, total)
+    exit_status_str = get_exit_status_string(exit_counts, total)
 
     # set up report detail
-    report_string = f"\n## Test Run Detail \nTest was run with the following arguments:\n{args}\n\n"
-    report_string += "| Test | Exit Status | Mean Benchmark Time (ms) | Notes |\n"
-    report_string += "|--|--|--|--|\n"
-    for (key, value) in status_dict.items():
-        report_string += f"| {key} | {value['exit_status']} | {value['time_ms']} | |\n"
+    args_string = (
+        f"## Test Run Detail\nTest was run with the following arguments:\n{args}\n\n"
+    )
 
-    # get a report file and write to it 
+    detail_string = get_detail_string(status_dict)
+
+    # get a report file and write to it
     with open(args.report_file, "w") as file:
         file.write(results_str)
-        file.write(report_string)
+        file.write(exit_status_str)
+        file.write(args_string)
+        file.write(detail_string)


### PR DESCRIPTION
Here is a sample from testing the migraphx models:

## Passing Summary

**TOTAL TESTS = 30**
|Stage|# Passing|% of Total|% of Attempted|
|--|--|--|--|
| Setup | 30 | 100.0% | 100.0% |
| IREE Compilation | 20 | 66.7% | 66.7% |
| Gold Inference | 18 | 60.0% | 90.0% |
| IREE Inference Invocation | 16 | 53.3% | 88.9% |
| Inference Comparison (PASS) | 12 | 40.0% | 75.0% |
## Fail Summary

**TOTAL TESTS = 30**
|Stage|# Failed at Stage|% of Total|
|--|--|--|
| Setup | 0 | 0.0% |
| IREE Compilation | 10 | 33.3% |
| Gold Inference | 2 | 6.7% |
| IREE Inference Invocation | 2 | 6.7% |
| Inference Comparison | 4 | 13.3% |
## Test Run Detail
Test was run with the following arguments:
Namespace(device='local-task', backend='llvm-cpu', iree_compile_args=None, mode='cl-onnx-iree', torchtolinalg=False, stages=None, skip_stages=None, benchmark=False, load_inputs=False, groups='all', test_filter='migraphx', testsfile=None, tolerance=None, verbose=True, rundirectory='test-run', no_artifacts=False, cleanup='0', report=True, report_file='report.md', xfail_file=None, update_xfails=False)

| Test | Exit Status | Mean Benchmark Time (ms) | Notes |
|--|--|--|--|
| migraphx_agentmodel__AgentModel | compilation | None | |
| migraphx_bert__bert-large-uncased | compilation | None | |
| migraphx_bert__bertsquad-12 | compilation | None | |
| migraphx_cadene__dpn92i1 | PASS | None | |
| migraphx_cadene__inceptionv4i16 | PASS | None | |
| migraphx_cadene__resnext101_64x4di1 | PASS | None | |
| migraphx_cadene__resnext101_64x4di16 | PASS | None | |
| migraphx_huggingface-transformers__bert_mrpc8 | native_inference | None | |
| migraphx_mlperf__bert_large_mlperf | Numerics | None | |
| migraphx_mlperf__resnet50_v1 | PASS | None | |
| migraphx_models__whisper-tiny-decoder | compiled_inference | None | |
| migraphx_models__whisper-tiny-encoder | native_inference | None | |
| migraphx_onnx-misc__taau_low_res_downsample_d2s_for_infer_time_fp16_opset11 | import_model | None | |
| migraphx_onnx-model-zoo__gpt2-10 | compilation | None | |
| migraphx_ORT__bert_base_cased_1 | PASS | None | |
| migraphx_ORT__bert_base_uncased_1 | compilation | None | |
| migraphx_ORT__bert_large_uncased_1 | PASS | None | |
| migraphx_ORT__distilgpt2_1 | compiled_inference | None | |
| migraphx_ORT__onnx_models__bert_base_cased_1_fp16_gpu | Numerics | None | |
| migraphx_ORT__onnx_models__bert_large_uncased_1_fp16_gpu | Numerics | None | |
| migraphx_ORT__onnx_models__distilgpt2_1_fp16_gpu | Numerics | None | |
| migraphx_pytorch-examples__wlang_gru | compilation | None | |
| migraphx_pytorch-examples__wlang_lstm | compilation | None | |
| migraphx_sd__unet__model | import_model | None | |
| migraphx_sdxl__unet__model | import_model | None | |
| migraphx_torchvision__densenet121i32 | PASS | None | |
| migraphx_torchvision__inceptioni1 | PASS | None | |
| migraphx_torchvision__inceptioni32 | PASS | None | |
| migraphx_torchvision__resnet50i1 | PASS | None | |
| migraphx_torchvision__resnet50i64 | PASS | None | |
