### PR TITLE
Fix bert nlp models failing input generation by overriding `token_type_ids` to limit its range to [0,2) and some refactoring

### DIFF
--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -68,7 +68,7 @@ class OnnxModelInfo:
             f"Model path {self.model} does not exist and no construct_model method is defined."
         )
 
-    def construct_inputs(self):
+    def construct_inputs(self) -> TestTensors:
         """can be overridden to generate specific inputs, but a default is provided for convenience"""
         if not os.path.exists(self.model):
             self.construct_model()


### PR DESCRIPTION
Note: this causes each nlp model to create an additional onnx inference session. A larger scale refactoring may be required to fix this.

Testing: I ran this on local with a bert model and was able to get to a numeric mismatch.

Full list of changes:

1. Refactor input generation for ONNX models:
   - Split `get_node_shape_from_dim_param_dict()` out of 
     `generate_input_from_node()` for better modularity.
   - Improve docstrings for better function descriptions.

2. Enhance type annotations:
   - Add return type hints to `construct_inputs()` and 
     `get_sample_inputs_for_onnx_model()`.
   - Use `TestTensors` type consistently for input/output tensors.

3. Fix NLP(Bert)-specific input generation:
   - Override `construct_inputs()` in NLP models to handle 'token_type_ids'
     correctly.

