### PR TITLE
Bert fix + a bunch of refactoring

### DIFF
--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -68,7 +68,7 @@ class OnnxModelInfo:
             f"Model path {self.model} does not exist and no construct_model method is defined."
         )
 
-    def construct_inputs(self):
+    def construct_inputs(self) -> TestTensors:
         """can be overridden to generate specific inputs, but a default is provided for convenience"""
         if not os.path.exists(self.model):
             self.construct_model()

--- a/alt_e2eshark/e2e_testing/onnx_utils.py
+++ b/alt_e2eshark/e2e_testing/onnx_utils.py
@@ -74,14 +74,10 @@ def generate_input_from_node(node: onnxruntime.capi.onnxruntime_pybind11_state.N
     raise NotImplementedError(f"Found an unhandled dtype: {node.type}.")
 
 
-def get_sample_inputs_for_onnx_model(model_path, dim_param_dict = None) -> TestTensors:
+def get_sample_inputs_for_onnx_model(input_nodes, dim_param_dict = None) -> TestTensors:
     """A convenience function for generating sample inputs for an onnx model"""
-    opt = onnxruntime.SessionOptions()
-    opt.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
-    s = onnxruntime.InferenceSession(model_path, opt)
-    inputs = s.get_inputs()
     sample_inputs = TestTensors(
-        tuple([generate_input_from_node(node, dim_param_dict) for node in inputs])
+        tuple([generate_input_from_node(node, dim_param_dict) for node in input_nodes])
     )
     return sample_inputs
 

--- a/alt_e2eshark/onnx_tests/models/nlp.py
+++ b/alt_e2eshark/onnx_tests/models/nlp.py
@@ -41,10 +41,9 @@ def dim_param_constructor(dim_param_dict):
             tensors = list(default_inputs.data)
 
             self.update_sess_options()
-            session = ort.InferenceSession(self.model, self.sess_options)
 
             # nlp specific overrides
-            for i, node in enumerate(session.get_inputs()):
+            for i, node in enumerate(self.ort_input_nodes):
                 if node.name == "token_type_ids":
                     rng = numpy.random.default_rng(19)
                     int_dims = get_node_shape_from_dim_param_dict(node, self.dim_param_dict)

--- a/alt_e2eshark/onnx_tests/models/opt_models.py
+++ b/alt_e2eshark/onnx_tests/models/opt_models.py
@@ -83,7 +83,7 @@ class Opt125MGPTQModelInfo(OnnxModelInfo):
         torch.onnx.export(
             self.pytorch_model,
             (self.encoding["input_ids"], self.encoding["attention_mask"]),
-            self.model,
+            self._model,
             opset_version=20,
         )
 

--- a/alt_e2eshark/onnx_tests/operators/generate_node.py
+++ b/alt_e2eshark/onnx_tests/operators/generate_node.py
@@ -40,8 +40,7 @@ class NodeTest(OnnxModelInfo):
         self.model = onnx_node_tests_dir + self.name + "/model.onnx"
 
     def construct_inputs(self):
-        model = onnx.load(self.model)
-        inputs = model.graph.input
+        inputs = len(self.ort_input_nodes)
         num_inputs = len(inputs)
         input_list = []
         for i in range(num_inputs):

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -392,7 +392,7 @@ def _get_argparse():
     parser.add_argument(
         "-t",
         "--test-filter",
-        help="Run given specific test(s) only",
+        help="Run tests matching regex filter only.",
     )
     parser.add_argument(
         "--testsfile",


### PR DESCRIPTION
This includes everything from https://github.com/nod-ai/SHARK-TestSuite/pull/357 and the following changes to make the runs fast and make the code (hopefully) easier to maintain:

1. OnnxModelInfo class refactoring:
   - Added `__slots__` to optimize memory usage
   - Introduced properties for `model`, `ort_inference_session`, `ort_input_nodes`, and `ort_output_nodes`
   - Lazy loading of ONNX model and inference session
   - Caching of input and output nodes

2. Performance improvements:
   - Reduced redundant file existence checks and model loading
   - Optimized session creation and management

3. Type hinting and imports:
   - Added `List` and `final` to imports from typing module

4. Changes to helper classes:
   - Updated `AzureDownloadableModel`, `SiblingModel`, and `TruncatedModel` to work with the refactored `OnnxModelInfo`
   - Adjusted model path handling to use `self._model` instead of `self.model` in some cases

5. Minor updates to other files:
   - Modified `get_sample_inputs_for_onnx_model` function to accept input nodes directly
   - Updated various model construction and input generation methods to work with the refactored classes

6. Command-line argument change:
   - Updated help text for `-t` / `--test-filter` argument to indicate it uses regex filtering

These changes appear to focus on improving performance, reducing redundant operations, and making the code more maintainable through better encapsulation and lazy loading of resources.