### PR TITLE
[alt] fix for issue with input generation

### DIFF
--- a/alt_e2eshark/e2e_testing/onnx_utils.py
+++ b/alt_e2eshark/e2e_testing/onnx_utils.py
@@ -45,6 +45,7 @@ def get_node_shape_from_dim_param_dict(node: onnxruntime.capi.onnxruntime_pybind
             raise ValueError(
                 f"input node '{node.name}' has a non-positive dim: {dim}. Consider setting cutsom inputs for this test."
             )
+        int_dims.append(dim)
     return int_dims
 
 


### PR DESCRIPTION
In <https://github.com/nod-ai/SHARK-TestSuite/commit/776822a59c10a47c1778a5b4b8d257c34bba9ee5>, a line of code was erroneously removed, resulting in a failure to get the input shape for static dims. 

This adds back in the missing line to append the static shapes to the int_dims list. 