### PR TITLE
fix some test setups causing import failures

### DIFF
--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from ..helper_classes import AzureDownloadableModel
 from e2e_testing.registry import register_test
 from e2e_testing.storage import load_test_txt_file
+import onnx
 import onnxruntime
 
 this_file = Path(__file__)
@@ -24,6 +25,19 @@ custom_registry = [
     "opt-125M-awq",
     "opt-125m-gptq",
     "DeepLabV3_resnet50_vaiq_int8",
+]
+
+no_opset_update = [
+    "dm_nfnet_f2.dm_in1k",
+    "dm_nfnet_f3.dm_in1k",
+    "dm_nfnet_f4.dm_in1k",
+    "dm_nfnet_f5.dm_in1k",
+    "dm_nfnet_f6.dm_in1k",
+    "vit_base_r50_s16_384.orig_in21k_ft_in1k",
+    "vit_small_r26_s32_224.augreg_in21k_ft_in1k",
+    "vit_small_r26_s32_384.augreg_in21k_ft_in1k",
+    "vit_tiny_r_s16_p8_224.augreg_in21k_ft_in1k",
+    "vit_tiny_r_s16_p8_384.augreg_in21k_ft_in1k",
 ]
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:
@@ -87,7 +101,14 @@ basic_opt = [
     "xcit_tiny_24_p8_384_dist",
 ]
 
+remove_metadata_props = [
+    "resnetv2_50x1_bit.goog_in21k_ft_in1k_vaiq",
+]
+
 custom_registry += basic_opt
+custom_registry += no_opset_update
+custom_registry += remove_metadata_props
+
 # for simple models without dim params or additional customization, we should be able to register them directly with AzureDownloadableModel
 # TODO: many of the models in the text files loaded from above will likely need to be registered with an alternative test info class.
 for t in set(model_names).difference(custom_registry):
@@ -113,3 +134,38 @@ class AzureWithOpt(AzureDownloadableModel):
 
 for t in basic_opt:
     register_test(AzureWithOpt, t)
+
+
+class AzureWithOptAndNoOpsetVersion(AzureWithOpt):
+    def __init__(self, name: str, onnx_model_path: str):
+        super().__init__(name, onnx_model_path)
+        self.opset_version = None
+
+
+for t in no_opset_update:
+    register_test(AzureWithOptAndNoOpsetVersion, t)
+
+
+class AzureRemoveMetadataProps(AzureDownloadableModel):
+    def construct_model(self):
+        super().construct_model()
+        self.remove_duplicate_metadata_props()
+
+    def remove_duplicate_metadata_props(self):
+        model = onnx.load(self.model)
+        metadata = model.metadata_props
+        # unhashable type, so manually check for duplicates
+        to_remove = []
+        for i, m0 in enumerate(metadata):
+            for j in range(i + 1, len(metadata)):
+                if m0 == metadata[j]:
+                    to_remove.append(i)
+        num_removed = 0
+        for i in to_remove:
+            _ = metadata.pop(i - num_removed)
+        mod_model_path = str(Path(self.model).parent / "model.modified.onnx")
+        onnx.save(model, mod_model_path)
+        self.model = mod_model_path
+
+
+register_test(AzureRemoveMetadataProps, "resnetv2_50x1_bit.goog_in21k_ft_in1k_vaiq")

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -29,10 +29,10 @@ custom_registry = [
 
 no_opset_update = [
     "dm_nfnet_f2.dm_in1k",
-    "dm_nfnet_f3.dm_in1k",
-    "dm_nfnet_f4.dm_in1k",
-    "dm_nfnet_f5.dm_in1k",
-    "dm_nfnet_f6.dm_in1k",
+    # getting test runner crash for the following.
+    # TODO: unblock these when we externalize weights on import
+    # "dm_nfnet_f3.dm_in1k",
+    # "dm_nfnet_f4.dm_in1k",
     "vit_base_r50_s16_384.orig_in21k_ft_in1k",
     "vit_small_r26_s32_224.augreg_in21k_ft_in1k",
     "vit_small_r26_s32_384.augreg_in21k_ft_in1k",

--- a/alt_e2eshark/onnx_tests/models/nlp.py
+++ b/alt_e2eshark/onnx_tests/models/nlp.py
@@ -19,7 +19,7 @@ this_file = Path(__file__)
 lists_dir = (this_file.parent).joinpath("external_lists")
 
 model_names = []
-for i in [1,2,3]:
+for i in [1, 2, 3]:
     model_names += load_test_txt_file(lists_dir.joinpath(f"nlp-shard{i}.txt"))
 
 
@@ -47,17 +47,27 @@ def dim_param_constructor(dim_param_dict):
             for i, node in enumerate(session.get_inputs()):
                 if node.name == "token_type_ids":
                     rng = numpy.random.default_rng(19)
-                    int_dims = get_node_shape_from_dim_param_dict(node, self.dim_param_dict)
+                    int_dims = get_node_shape_from_dim_param_dict(
+                        node, self.dim_param_dict
+                    )
                     tensors[i] = rng.integers(0, 2, size=int_dims, dtype=numpy.int64)
             default_sample_inputs = TestTensors(tuple(tensors))
             return default_sample_inputs
+
     return AzureWithDimParams
+
 
 # Default dimension parameters for NLP models
 
-default_nlp_params = {"batch_size": 1, "seq_len": 128}
+# TODO: Verify these dim params are valid for each model, or load them from a json
+default_nlp_params = {
+    "batch_size": 1,
+    "seq_len": 128,
+    "encoder_sequence_length": 128,
+    "decoder_sequence_length": 128,
+}
 dim_aliases = [
-    {'seq_len', 'sequence_length'},
+    {"seq_len", "sequence_length"},
 ]
 for alias_set in dim_aliases:
     found = set(alias_set).intersection(default_nlp_params.keys())
@@ -65,8 +75,10 @@ for alias_set in dim_aliases:
         # check if the values are the same
         val = default_nlp_params[next(iter(found))]
         if not all(default_nlp_params[alias] == val for alias in found):
-            raise ValueError(f"Multiple aliases for the same dimension have different values: {found}")
-    
+            raise ValueError(
+                f"Multiple aliases for the same dimension have different values: {found}"
+            )
+
     aliases = alias_set - found
     for alias in aliases:
         default_nlp_params[alias] = default_nlp_params[next(iter(found))]
@@ -77,7 +89,7 @@ for model_name in model_names:
 
 # Custom dimension parameters for specific models
 custom_dim_params = {
-    # Add custom dimension parameters for specific models here 
+    # Add custom dimension parameters for specific models here
     # Example:
     # "model_name": {"batch_size": 1, "seq_len": 256, "custom_dim": 64},
 }
@@ -88,4 +100,3 @@ for model_name, dim_params in custom_dim_params.items():
         register_test(dim_param_constructor(dim_params), model_name)
 
 # You can add more customizations or specific handling for certain models here
-

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -172,7 +172,7 @@ def run_tests(
             os.makedirs(log_dir)
         
         # setup stage notifications
-        ws = lambda curr_stage : " "*(max(*[len(s) for s in stages]) - len(curr_stage))
+        ws = lambda curr_stage : " "*(max([len(s) for s in stages]) - len(curr_stage))
         notify_stage = lambda : print(f"\tRunning stage '{curr_stage}'..." + ws(curr_stage), end="\r")
 
         mean_time_ms = None


### PR DESCRIPTION
Resolves issues <https://github.com/nod-ai/SHARK-ModelDev/issues/860> <https://github.com/nod-ai/SHARK-ModelDev/issues/859> and <https://github.com/nod-ai/SHARK-ModelDev/issues/863>

- 5 tests should newly pass with this change (the vit models listed under "no_opset_update")
- 1 test "resnetv2_50x1_bit.goog_in21k_ft_in1k_vaiq" should go from an import fail to a Numerics fail.