### PR TITLE
make some adjustments to the torch-onnx to linalg pass pipeline

### DIFF
--- a/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
+++ b/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py
@@ -18,8 +18,14 @@ from pathlib import Path
 import json
 import shutil
 
+ONNX_TO_TORCH_BACKEND_PIPELINE = [
+    "func.func(convert-torch-onnx-to-torch)",
+]
+
 REDUCE_TO_LINALG_PIPELINE = [
     "torch-lower-to-backend-contract",
+    "func.func(torch-scalarize-shapes)",
+    "torch-shape-refinement-pipeline",
     "torch-backend-to-linalg-on-tensors-backend-pipeline",
 ]
 
@@ -94,7 +100,7 @@ class OnnxTestConfig(TestConfig):
         if not self.pass_pipeline:
             return mlir_module
         # convert imported torch-onnx ir to torch
-        onnx_to_torch_pipeline = "builtin.module(func.func(convert-torch-onnx-to-torch))"
+        onnx_to_torch_pipeline = "builtin.module("+",".join(ONNX_TO_TORCH_BACKEND_PIPELINE) + ")"
         with mlir_module.context as ctx:
             pm0 = PassManager.parse(onnx_to_torch_pipeline)
             pm0.run(mlir_module.operation)
@@ -175,7 +181,7 @@ class CLOnnxTestConfig(TestConfig):
         if not self.pass_pipeline:
             return mlir_module
         # convert imported torch-onnx ir to torch
-        onnx_to_torch_pipeline = "builtin.module(func.func(convert-torch-onnx-to-torch))"
+        onnx_to_torch_pipeline = "builtin.module("+",".join(ONNX_TO_TORCH_BACKEND_PIPELINE) + ")"
         # get paths
         detail_log = os.path.join(save_to, "detail", "preprocessing.detail.log")
         commands_log = os.path.join(save_to, "commands", "preprocessing.commands.log")

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -42,6 +42,10 @@ no_opset_update = [
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:
 basic_opt = [
+    "mvitv2_base",
+    "mvitv2_large",
+    "mvitv2_small",
+    "mvitv2_tiny",
     "gcvit_base",
     "gcvit_small",
     "gcvit_tiny",
@@ -169,3 +173,7 @@ class AzureRemoveMetadataProps(AzureDownloadableModel):
 
 
 register_test(AzureRemoveMetadataProps, "resnetv2_50x1_bit.goog_in21k_ft_in1k_vaiq")
+
+from ..helper_classes import TruncatedModel, get_trucated_constructor
+
+const = get_trucated_constructor(TruncatedModel, AzureDownloadableModel, "mvitv2_tiny")


### PR DESCRIPTION
I would normally add all of the torch related stuff to the "onnx-to-torch-backend-pipeline" but there is a common issue with slice ops having an int that's too big only when saving/loading an mlir file at the torch level. See <https://github.com/llvm/torch-mlir/issues/3621>.

Also adds a few models to the basic opt list, since they would need a whole 'nother cycle of shape inference and scalarization to clean themselves up. Good to know that it is possible to clean these up at the torch level though!