### PR TITLE
Fix int32 unpack buffer size

### DIFF
--- a/alt_e2eshark/e2e_testing/storage.py
+++ b/alt_e2eshark/e2e_testing/storage.py
@@ -47,7 +47,7 @@ def unpack_bytearray(barray, num_elem, dtype):
         rettensor = temptensor.view(dtype=torch.float16)
         return rettensor
     elif dtype == torch.int32:
-        num_array = struct.unpack("l" * num_elem, barray)
+        num_array = struct.unpack("i" * num_elem, barray)
     elif dtype == torch.int16:
         num_array = struct.unpack("h" * num_elem, barray)
     elif dtype == torch.int8:


### PR DESCRIPTION
The format character "l" corresponds to a 4-byte integer on some systems, but it can be 8 bytes on others, depending on the platform. To ensure consistency, use "i" for a 4-byte integer or "q" for an 8-byte integer explicitly.

```
python ./run.py --mode=cl-onnx-iree -v -t mygpt4_trunc_Reshape_0 --torchtolinalg
Stages to be run: ['setup', 'import_model', 'preprocessing', 'compilation', 'construct_inputs', 'native_inference', 'compiled_inference', 'postprocessing']
Test list: ['mygpt4_trunc_Reshape_0']
running test mygpt4_trunc_Reshape_0...
{'Shape': 1, 'Cast': 2, 'Slice': 1, 'Concat': 1, 'Reshape': 1}
        PASSED                               

Test Summary:
        PASSES: 1
        TOTAL: 1
results stored in /proj/gdba/shark/chi/src/SHARK-TestSuite/alt_e2eshark/test-run
```