### PR TITLE
cleans up `storage.py` and updates node tests

### DIFF
--- a/alt_e2eshark/e2e_testing/storage.py
+++ b/alt_e2eshark/e2e_testing/storage.py
@@ -11,66 +11,72 @@ from typing import Tuple, Optional, Dict, List, Any, Union
 from pathlib import Path
 import os
 
+TYPE_STRING_FROM_TORCH_DTYPE = {
+    torch.int64: "i64",
+    torch.uint64: "ui64",
+    torch.int32: "i32",
+    torch.uint32: "ui32",
+    torch.int16: "i16",
+    torch.int8: "i8",
+    torch.uint8: "ui8",
+    torch.bool: "i1",
+    torch.float64: "f64",
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+
+PACK_CHAR_FROM_TORCH_DTYPE = {
+    torch.int64: "q",
+    torch.uint64: "Q",
+    torch.int32: "i",
+    torch.uint32: "I",
+    torch.int16: "h",
+    torch.uint16: "H",
+    torch.int8: "b",
+    torch.uint8: "B",
+    torch.bool: "?",
+    torch.float64: "d",
+    torch.float32: "f",
+    torch.float16: "h",
+    torch.bfloat16: "h",
+}
+
+
 def get_shape_string(torch_tensor):
     input_shape = list(torch_tensor.shape)
     input_shape_string = "x".join([str(item) for item in input_shape])
     dtype = torch_tensor.dtype
-    if dtype == torch.int64:
-        input_shape_string += "xi64"
-    elif dtype == torch.int32:
-        input_shape_string += "xi32"
-    elif dtype == torch.float32 or dtype == torch.float:
-        input_shape_string += "xf32"
-    elif dtype == torch.bfloat16 or dtype == torch.float16 or dtype == torch.int16:
-        input_shape_string += "xbf16"
-    elif dtype == torch.int8:
-        input_shape_string += "xi8"
-    elif dtype == torch.bool:
-        input_shape_string += "xi1"
-    else:
-        raise NotImplementedError("In get_shape_string, found an unsupported data type: " + str(dtype))
-    return input_shape_string
+    if dtype not in TYPE_STRING_FROM_TORCH_DTYPE.keys():
+        raise NotImplementedError(
+            "In get_shape_string, found an unsupported data type: " + str(dtype)
+        )
+    dtype_str = TYPE_STRING_FROM_TORCH_DTYPE[torch_tensor.dtype]
+    return input_shape_string + "x" + dtype_str
 
 
 def unpack_bytearray(barray, num_elem, dtype):
-    num_array = None
-    if dtype == torch.int64:
-        num_array = struct.unpack("q" * num_elem, barray)
-    elif dtype == torch.float32 or dtype == torch.float:
-        num_array = struct.unpack("f" * num_elem, barray)
-    elif dtype == torch.bfloat16:
-        num_array = struct.unpack("h" * num_elem, barray)
+    if dtype not in PACK_CHAR_FROM_TORCH_DTYPE.keys():
+        raise NotImplementedError(
+            f"In unpack_bytearray, found an unsupported data type {dtype}"
+        )
+    num_array = struct.unpack(PACK_CHAR_FROM_TORCH_DTYPE[dtype] * num_elem, barray)
+    # special handling for f16, bf16
+    if dtype == torch.bfloat16 or dtype == torch.float16:
         temptensor = torch.tensor(num_array, dtype=torch.int16)
-        rettensor = temptensor.view(dtype=torch.bfloat16)
-        return rettensor
-    elif dtype == torch.float16:
-        num_array = struct.unpack("h" * num_elem, barray)
-        temptensor = torch.tensor(num_array, dtype=torch.int16)
-        rettensor = temptensor.view(dtype=torch.float16)
-        return rettensor
-    elif dtype == torch.int32:
-        num_array = struct.unpack("i" * num_elem, barray)
-    elif dtype == torch.int16:
-        num_array = struct.unpack("h" * num_elem, barray)
-    elif dtype == torch.int8:
-        num_array = struct.unpack("b" * num_elem, barray)
-    elif dtype == torch.uint8:
-        num_array = struct.unpack("B" * num_elem, barray)
-    elif dtype == torch.bool:
-        num_array = struct.unpack("?" * num_elem, barray)
-    else:
-        raise NotImplementedError(f"In unpack_bytearray, found an unsupported data type {dtype}")
-    rettensor = torch.tensor(num_array, dtype=dtype)
-    return rettensor
+        return temptensor.view(dtype=dtype)
+    return torch.tensor(num_array, dtype=dtype)
 
 
 def load_raw_binary_as_torch_tensor(binaryfile, shape, dtype):
-    '''given a shape and torch dtype, this will load a torch tensor from the specified binaryfile'''
+    """given a shape and torch dtype, this will load a torch tensor from the specified binaryfile"""
     # Read the whole files as bytes
     with open(binaryfile, "rb") as f:
         binarydata = f.read()
     # Number of elements in tensor
-    num_elem = torch.prod(torch.tensor(list(shape))) if len(shape) > 0 else torch.tensor([1])
+    num_elem = (
+        torch.prod(torch.tensor(list(shape))) if len(shape) > 0 else torch.tensor([1])
+    )
     # Total bytes
     tensor_num_bytes = (num_elem * dtype.itemsize).item()
     barray = bytearray(binarydata[0:tensor_num_bytes])
@@ -78,42 +84,22 @@ def load_raw_binary_as_torch_tensor(binaryfile, shape, dtype):
     #     print(f"{byte:02X}", end="")
     rettensor = unpack_bytearray(barray, num_elem, dtype)
     reshapedtensor = rettensor.reshape(list(shape))
-    f.close()
     return reshapedtensor
 
 
 def pack_tensor(modelinput):
     """stores a torch.Tensor into a binary file"""
-    mylist = modelinput.flatten().tolist()
     dtype = modelinput.dtype
-    if dtype == torch.int64:
-        bytearr = struct.pack("%sq" % len(mylist), *mylist)
-    elif dtype == torch.uint64:
-        bytearr = struct.pack("%sQ" % len(mylist), *mylist)
-    elif dtype == torch.int32:
-        bytearr = struct.pack("%si" % len(mylist), *mylist)
-    elif dtype == torch.uint32:
-        bytearr = struct.pack("%sI" % len(mylist), *mylist)
-    elif dtype == torch.float64:
-        bytearr = struct.pack("%sd" % len(mylist), *mylist)
-    elif dtype == torch.float32 or dtype == torch.float:
-        bytearr = struct.pack("%sf" % len(mylist), *mylist)
-    elif dtype == torch.bfloat16 or dtype == torch.float16:
-        reinterprted = modelinput.view(dtype=torch.int16)
-        mylist = reinterprted.flatten().tolist()
-        bytearr = struct.pack("%sh" % len(mylist), *mylist)
-    elif dtype == torch.int16:
-        bytearr = struct.pack("%sh" % len(mylist), *mylist)
-    elif dtype == torch.uint16:
-        bytearr = struct.pack("%sH" % len(mylist), *mylist)
-    elif dtype == torch.int8:
-        bytearr = struct.pack("%sb" % len(mylist), *mylist)
-    elif dtype == torch.uint8:
-        bytearr = struct.pack("%sB" % len(mylist), *mylist)
-    elif dtype == torch.bool:
-        bytearr = struct.pack("%s?" % len(mylist), *mylist)
-    else:
-        raise NotImplementedError(f"In pack_tensor, found an unsupported data type {dtype}")
+    if dtype not in PACK_CHAR_FROM_TORCH_DTYPE.keys():
+        raise NotImplementedError(
+            f"In pack_tensor, found an unsupported data type {dtype}"
+        )
+    if dtype == torch.float16 or dtype == torch.bfloat16:
+        modelinput = modelinput.view(dtype.torch.int16)
+    mylist = modelinput.flatten().tolist()
+    bytearr = struct.pack(
+        f"%s{PACK_CHAR_FROM_TORCH_DTYPE[dtype]}" % len(mylist), *mylist
+    )
     return bytearr
 
 
@@ -122,17 +108,19 @@ def write_inference_input_bin_file(modelinput, modelinputbinfilename):
     with open(modelinputbinfilename, "wb") as f:
         bytearr = pack_tensor(modelinput)
         f.write(bytearr)
-        f.close()
 
-def load_test_txt_file(filepath : Union[str, Path]) -> List[str]:
+
+def load_test_txt_file(filepath: Union[str, Path]) -> List[str]:
     with open(filepath, "r") as file:
         contents = file.read().split()
     return contents
+
 
 def load_json_dict(filepath: Union[str, Path]) -> Dict[str, Any]:
     with open(filepath) as contents:
         loaded_dict = json.load(contents)
     return loaded_dict
+
 
 class TestTensors:
     """storage class for tuples of tensor-like objects"""
@@ -145,7 +133,7 @@ class TestTensors:
     def __init__(self, data: Tuple):
         self.data = data
         self.type = None
-        if len(data) > 0 :
+        if len(data) > 0:
             self.type = type(self.data[0])
         if not all([type(d) == self.type for d in data]):
             self.type == None
@@ -207,15 +195,19 @@ class TestTensors:
             data = self.to_torch().data
         for i in range(len(data)):
             write_inference_input_bin_file(data[i], path + f".{i}.bin")
-    
+
     @staticmethod
     def load_from(shapes, torch_dtypes, dir_path: str, name: str = "input"):
-        '''loads bin files. dir_path should end in a forward slash and should contain files of the type {name}.0.bin, {name}.1.bin, etc.'''
+        """loads bin files. dir_path should end in a forward slash and should contain files of the type {name}.0.bin, {name}.1.bin, etc."""
         tensor_list = []
-        assert len(shapes) == len(torch_dtypes), "must provide same number of shapes and dtypes"
+        assert len(shapes) == len(
+            torch_dtypes
+        ), "must provide same number of shapes and dtypes"
         for i in range(len(shapes)):
             shape = shapes[i]
             dtype = torch_dtypes[i]
-            t = load_raw_binary_as_torch_tensor(os.path.join(dir_path, name + "." + str(i) + ".bin"), shape, dtype)
+            t = load_raw_binary_as_torch_tensor(
+                os.path.join(dir_path, name + "." + str(i) + ".bin"), shape, dtype
+            )
             tensor_list.append(t)
         return TestTensors(tuple(tensor_list))

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -141,7 +141,7 @@ class TruncatedModel(SiblingModel):
         print(get_op_frequency(self.model))
 
 
-def get_trucated_constructor(truncated_class, og_constructor, og_name):
+def get_truncated_constructor(truncated_class, og_constructor, og_name):
     """returns a function that takes in (n, op_type) and returns a constructor for the truncated class.
 
     Usage:

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -174,6 +174,6 @@ class AzureRemoveMetadataProps(AzureDownloadableModel):
 
 register_test(AzureRemoveMetadataProps, "resnetv2_50x1_bit.goog_in21k_ft_in1k_vaiq")
 
-from ..helper_classes import TruncatedModel, get_trucated_constructor
+from ..helper_classes import TruncatedModel, get_truncated_constructor
 
-const = get_trucated_constructor(TruncatedModel, AzureDownloadableModel, "mvitv2_tiny")
+const = get_truncated_constructor(TruncatedModel, AzureDownloadableModel, "mvitv2_tiny")

--- a/alt_e2eshark/onnx_tests/models/migraphx.py
+++ b/alt_e2eshark/onnx_tests/models/migraphx.py
@@ -151,9 +151,9 @@ need_repro_dict = {
     "migraphx_onnx-model-zoo__gpt2-10": ["gpt2_10", 0, "NonZero"],
 }
 
-from ..helper_classes import TruncatedModel, get_trucated_constructor
+from ..helper_classes import TruncatedModel, get_truncated_constructor
 
-trunc_const = lambda key: get_trucated_constructor(
+trunc_const = lambda key: get_truncated_constructor(
     TruncatedModel, dim_param_constructor(llm_dict_0), key
 )
 

--- a/alt_e2eshark/onnx_tests/models/vision_models.py
+++ b/alt_e2eshark/onnx_tests/models/vision_models.py
@@ -41,6 +41,6 @@ constructor3 = get_sibling_constructor(NoOptimizations, AzureDownloadableModel, 
 register_test(constructor2, "resnet50_vaiq_int8_no_opt")
 register_test(constructor3, "ResNet50_vaiq_no_opt")
 
-# truncated_constructor = get_trucated_constructor(TruncatedModel, AzureDownloadableModel, "ResNet50_vaiq")
+# truncated_constructor = get_truncated_constructor(TruncatedModel, AzureDownloadableModel, "ResNet50_vaiq")
 # for n in range(4, 10):
 #     register_test(truncated_constructor(n,""), f"ResNet50_vaiq_trunc_{n}")

--- a/alt_e2eshark/onnx_tests/operators/generate_node.py
+++ b/alt_e2eshark/onnx_tests/operators/generate_node.py
@@ -31,7 +31,7 @@ base_dir = Path(onnx.__file__).parent
 # base_dir = str(Path(__file__).parents[3]) + "/third_party/onnx"
 onnx_node_tests_dir = base_dir / "backend" / "test" / "data" / "node"
 
-names = [x.name for x in onnx_node_tests_dir.glob("*") if x.isdir()]
+names = [x.name for x in onnx_node_tests_dir.glob("*") if x.is_dir()]
 
 
 class NodeTest(OnnxModelInfo):

--- a/alt_e2eshark/onnx_tests/operators/generate_node.py
+++ b/alt_e2eshark/onnx_tests/operators/generate_node.py
@@ -26,18 +26,19 @@ def get_tensor_from_pb(inputpb):
     return t
 
 
-base_dir = getsitepackages()[0]
+base_dir = Path(onnx.__file__).parent
 # you can also get the node tests from the git submodule instead by uncommenting:
 # base_dir = str(Path(__file__).parents[3]) + "/third_party/onnx"
-onnx_node_tests_dir = base_dir + "/onnx/backend/test/data/node/"
+onnx_node_tests_dir = base_dir / "backend" / "test" / "data" / "node"
 
-names = os.listdir(onnx_node_tests_dir) if os.path.exists(onnx_node_tests_dir) else []
+names = [x.name for x in onnx_node_tests_dir.glob("*") if x.isdir()]
 
 
 class NodeTest(OnnxModelInfo):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.model = onnx_node_tests_dir + self.name + "/model.onnx"
+        self.model = str(onnx_node_tests_dir / self.name / "model.onnx")
+        self.opset_version = 17
 
     def construct_inputs(self):
         model = onnx.load(self.model)
@@ -45,7 +46,9 @@ class NodeTest(OnnxModelInfo):
         num_inputs = len(inputs)
         input_list = []
         for i in range(num_inputs):
-            inputpb = f"{onnx_node_tests_dir}{self.name}/test_data_set_0/input_{i}.pb"
+            inputpb = str(
+                onnx_node_tests_dir / self.name / "test_data_set_0" / f"input_{i}.pb"
+            )
             input_list.append(get_tensor_from_pb(inputpb))
         return TestTensors(input_list)
 
@@ -55,7 +58,9 @@ class NodeTest(OnnxModelInfo):
         num_outputs = len(outputs)
         output_list = []
         for i in range(num_outputs):
-            outputpb = f"{onnx_node_tests_dir}{self.name}/test_data_set_0/output_{i}.pb"
+            outputpb = str(
+                onnx_node_tests_dir / self.name / "test_data_set_0" / f"output_{i}.pb"
+            )
             output_list.append(get_tensor_from_pb(outputpb))
         return TestTensors(output_list)
 

--- a/alt_e2eshark/onnx_tests/operators/generate_node.py
+++ b/alt_e2eshark/onnx_tests/operators/generate_node.py
@@ -38,7 +38,7 @@ class NodeTest(OnnxModelInfo):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.model = str(onnx_node_tests_dir / self.name / "model.onnx")
-        self.opset_version = 17
+        self.opset_version = 21
 
     def construct_inputs(self):
         model = onnx.load(self.model)


### PR DESCRIPTION
Uses dictionaries to associate torch dtypes to various strings used in storage utility functions. 

Also sets opset versions for node tests and cleans up the code there.