### PR TITLE
Pulling in Alt E2ESHARK CI changes

### DIFF
--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -7,9 +7,9 @@
 name: E2ESHARK Test Suite
 on:
   workflow_dispatch:
-  # schedule:
-  # # Runs at 12:00 PM UTC, which is 5:00 AM PST
-  #  - cron: '0 12 * * *'
+  schedule:
+  # Runs at 2:30 AM PST
+   - cron: '30 9 * * *'
 
 jobs: 
   e2eshark:

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -119,26 +119,26 @@ jobs:
             test-file: nlp-shard1
             cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard2_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: nlp-shard2
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard3_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: nlp-shard3
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard4_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: shark-test-suite
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard5_test
             runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
@@ -161,40 +161,40 @@ jobs:
             test-file: vai-hf-cnn-fp32-shard3
             cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard8_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: vai-int8-p0p1-shard1
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard9_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: vai-int8-p0p1-shard2
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard10_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: vai-int8-p0p1-shard3
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard11_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: vai-vision-int8
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard12_test
-            runs-on: large-cpu
+            runs-on: nodai-amdgpu-mi250-x86-64
             backend: llvm-cpu
             device: local-task
             target-chip: x86_64-linux-gnu
             test-file: migraphx
-            cache-dir: /home/sai/test-suite-ci-cache
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           # - name: cpu_shard13_test
           #   runs-on: nodai-amdgpu-mi250-x86-64
           #   backend: llvm-cpu

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -11,127 +11,552 @@ on:
   # # Runs at 12:00 PM UTC, which is 5:00 AM PST
   #  - cron: '0 12 * * *'
 
-jobs:
+jobs: 
   e2eshark:
-    runs-on: nodai-amdgpu-mi250-x86-64
+    timeout-minutes: 600
+    name: "Models :: ${{ matrix.backend }} :: ${{ matrix.test-file }}"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: mi300_gpu1_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: nlp-shard1
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu2_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: nlp-shard2
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu3_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: nlp-shard3
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu4_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: shark-test-suite
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          # - name: mi300_gpu5_test
+          #   runs-on: nodai-amdgpu-mi300-x86-64
+          #   backend: rocm
+          #   device: hip
+          #   target-chip: gfx942
+          #   test-file: vai-hf-cnn-fp32-shard1
+          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          # - name: mi300_gpu6_test
+          #   runs-on: nodai-amdgpu-mi300-x86-64
+          #   backend: rocm
+          #   device: hip
+          #   target-chip: gfx942
+          #   test-file: vai-hf-cnn-fp32-shard2
+          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          # - name: mi300_gpu7_test
+          #   runs-on: nodai-amdgpu-mi300-x86-64
+          #   backend: rocm
+          #   device: hip
+          #   target-chip: gfx942
+          #   test-file: vai-hf-cnn-fp32-shard3
+          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu8_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-int8-p0p1-shard1
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu9_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-int8-p0p1-shard2
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu10_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-int8-p0p1-shard3
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu11_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-vision-int8
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu12_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: migraphx
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          # - name: mi300_gpu13_test
+          #   runs-on: nodai-amdgpu-mi300-x86-64
+          #   backend: hip
+          #   device: hip
+          #   target-chip: gfx942
+          #   test-file: onnxrt-iree-ep
+          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: cpu_shard1_test
+            runs-on: nodai-amdgpu-mi250-x86-64
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: nlp-shard1
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          - name: cpu_shard2_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: nlp-shard2
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard3_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: nlp-shard3
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard4_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: shark-test-suite
+            cache-dir: /home/sai/test-suite-ci-cache
+          # - name: cpu_shard5_test
+          #   runs-on: nodai-amdgpu-mi250-x86-64
+          #   backend: llvm-cpu
+          #   device: local-task
+          #   target-chip: x86_64-linux-gnu
+          #   test-file: vai-hf-cnn-fp32-shard1
+          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          # - name: cpu_shard6_test
+          #   runs-on: nodai-amdgpu-mi250-x86-64
+          #   backend: llvm-cpu
+          #   device: local-task
+          #   target-chip: x86_64-linux-gnu
+          #   test-file: vai-hf-cnn-fp32-shard2
+          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          # - name: cpu_shard7_test
+          #   runs-on: nodai-amdgpu-mi250-x86-64
+          #   backend: llvm-cpu
+          #   device: local-task
+          #   target-chip: x86_64-linux-gnu
+          #   test-file: vai-hf-cnn-fp32-shard3
+          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          - name: cpu_shard8_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-int8-p0p1-shard1
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard9_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-int8-p0p1-shard2
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard10_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-int8-p0p1-shard3
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard11_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-vision-int8
+            cache-dir: /home/sai/test-suite-ci-cache
+          - name: cpu_shard12_test
+            runs-on: large-cpu
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: migraphx
+            cache-dir: /home/sai/test-suite-ci-cache
+          # - name: cpu_shard13_test
+          #   runs-on: nodai-amdgpu-mi250-x86-64
+          #   backend: llvm-cpu
+          #   device: local-task
+          #   target-chip: x86_64-linux-gnu
+          #   test-file: onnxrt-iree-ep
+          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
     env:
       E2E_VENV_DIR: ${{ github.workspace }}/test-suite_venv
+      EP_VENV_DIR: ${{ github.workspace }}/ep_venv
+      ALT_E2E_VENV_DIR: ${{ github.workspace }}/alt-test-suite_venv
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       AZ_PRIVATE_CONNECTION: ${{ secrets.ONNXPRIVATESTORAGE_AZ_PRIVATE_CONNECTION }}
+      CACHE_DIR: ${{ matrix.cache-dir }}
     steps:
       - name: Checkout Test Suite
         uses: actions/checkout@v2
         with:
           repository: nod-ai/SHARK-TestSuite
+          ref: alt-merge-reports
           path: test-suite
-
-      - name: Checkout SHARK Turbine
-        uses: actions/checkout@v2
-        with:
-          repository: nod-ai/SHARK-Turbine
-          path: SHARK-Turbine
-
-      - name: Checkout iree turbine
-        uses: actions/checkout@v2
-        with:
-          repository: iree-org/iree-turbine
-          path: iree-turbine
-
-      - name: "Setup e2eshark python venv"
+      
+      - name: "Setup alt e2eshark python venv"
         run: |
-          python3.11 -m venv ${E2E_VENV_DIR}
-          source ${E2E_VENV_DIR}/bin/activate
+          rm -rf ${ALT_E2E_VENV_DIR}
+          python3.11 -m venv ${ALT_E2E_VENV_DIR}
+          source ${ALT_E2E_VENV_DIR}/bin/activate
           pip install --upgrade pip
-          pip install -r ./e2eshark/requirements.txt
-          pip uninstall -y numpy
-          pip install numpy==1.26.3
-          pip install --upgrade transformers
-          pip install \
-            --find-links https://iree.dev/pip-release-links.html \
-            --upgrade \
-            iree-compiler \
-            iree-runtime
-          pip install \
-            --find-links https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels \
-            --upgrade \
-            torch-mlir
+          pip install -r ./alt_e2eshark/base_requirements.txt
+          pip install -r ./alt_e2eshark/iree_requirements.txt
+          pip install --no-deps -r ./alt_e2eshark/torch_mlir_requirements.txt
+          pip install --find-links https://iree.dev/pip-release-links.html iree-compiler iree-runtime --upgrade
+        working-directory: ./test-suite
+      
+      - name: "Setup IREE EP python venv"
+        run: |
+          python3.11 -m venv ${EP_VENV_DIR}
+          source ${EP_VENV_DIR}/bin/activate
+          pip install --upgrade pip
+          pip install -r ./alt_e2eshark/base_requirements.txt
+          pip install -r ./alt_e2eshark/iree_requirements.txt
+          pip install --no-deps -r ./alt_e2eshark/torch_mlir_requirements.txt
+          pip uninstall -y onnxruntime
+          wget https://sharkpublic.blob.core.windows.net/sharkpublic/onnxruntime/pip_whl/onnxruntime-1.20.0-cp311-cp311-linux_x86_64.whl
+          pip install ./onnxruntime-1.20.0-cp311-cp311-linux_x86_64.whl
         working-directory: ./test-suite
 
-      - name: Run Onnx Mode
+      - name: Run Onnx Bench Mode
+        if: contains(matrix.test-file, 'migraphx')
         run: |
-          source ${E2E_VENV_DIR}/bin/activate
-          pip list
-          cd e2eshark
+          source ${ALT_E2E_VENV_DIR}/bin/activate
+          pip freeze
+          cd alt_e2eshark
           free -mh
           python3.11 ./run.py \
             -r ./test-onnx \
             --report \
-            --cachedir /groups/aig_sharks/test-suite-ci-cache \
-            --testsfile ./ci-list.txt \
-            --mode onnx \
-            -f onnx pytorch \
-            -g models \
-            --tolerance .01 .01 \
-            --cleanup \
-            --postprocess \
-            --ci \
+            --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
+            -b ${{ matrix.backend }} \
+            -d ${{ matrix.device }} \
+            --report-file reports/${{ matrix.test-file }}.md \
+            --mode=cl-onnx-iree \
+            --cleanup=3 \
+            --benchmark \
+            --get-metadata \
             -v
+          python utils/find_duplicate_models.py -s -r ./test-onnx -o reports/duplicates.json
         working-directory: ./test-suite
 
-      - name: Setup turbine python venv
+      - name: Run Onnx Default Mode
+        if: ${{ ! contains(matrix.test-file, 'migraphx') && ! contains(matrix.test-file, 'onnxrt-iree-ep') }}
         run: |
-          source ${E2E_VENV_DIR}/bin/activate
-          pip install -f https://iree.dev/pip-release-links.html --upgrade \
-          -r ../iree-turbine/iree-requirements.txt
-          pip install -e ../iree-turbine[testing]
-          pip install --no-compile --pre --upgrade -e ../SHARK-Turbine/models -r ../SHARK-Turbine/models/requirements.txt
-        working-directory: ./test-suite
-
-      - name: Run Turbine Mode
-        run: |
-          source ${E2E_VENV_DIR}/bin/activate
-          cd e2eshark
+          source ${ALT_E2E_VENV_DIR}/bin/activate
+          pip freeze
+          cd alt_e2eshark
           free -mh
-          HF_TOKEN=${{ secrets.HF_TOKEN }} python3.11 ./run.py \
-          -r ./test-turbine \
-          --report \
-          --cachedir /groups/aig_sharks/test-suite-ci-cache \
-          --mode turbine \
-          -g models \
-          --cleanup \
-          --postprocess \
-          --ci \
-          -v
+          python3.11 ./run.py \
+            -r ./test-onnx \
+            --report \
+            --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
+            -b ${{ matrix.backend }} \
+            -d ${{ matrix.device }} \
+            --report-file reports/${{ matrix.test-file }}.md \
+            --mode=cl-onnx-iree \
+            --cleanup=3 \
+            --get-metadata \
+            -v
+          python utils/find_duplicate_models.py -s -r ./test-onnx -o reports/duplicates.json
         working-directory: ./test-suite
+      
+      - name: Run OnnxRT IREE EP
+        if: contains(matrix.test-file, 'onnxrt-iree-ep')
+        run: |
+          source ${EP_VENV_DIR}/bin/activate
+          export COMPILER_PATH=$(python -c "import iree.compiler as _; print(_.__path__[0])")
+          export LD_LIBRARY_PATH="$COMPILER_PATH/_mlir_libs/"
+          echo "COMPILER_PATH=$COMPILER_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          pip freeze
+          cd alt_e2eshark
+          free -mh
+          python ./run.py -m ort-ep \
+            -r ./test-onnx \
+            --report \
+            --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
+            -b ${{ matrix.backend }} \
+            -d ${{ matrix.device }} \
+            --report-file reports/${{ matrix.test-file }}.md \
+            --cleanup=3 \
+            --get-metadata \
+            -v
+          python utils/find_duplicate_models.py -s -r ./test-onnx -o reports/duplicates.json
+        working-directory: ./test-suite
+
+      - uses: actions/upload-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_${{ matrix.test-file }}_onnx_md
+          path: ./test-suite/alt_e2eshark/reports/${{ matrix.test-file }}.md
       
       - uses: actions/upload-artifact@master
         with:
-          name: ci_reports
-          path: ./test-suite/e2eshark/ci_reports
+          name: ci_reports_${{ matrix.backend }}_${{ matrix.test-file }}_onnx_json
+          path: ./test-suite/alt_e2eshark/reports/${{ matrix.test-file }}.json
+      
+      - uses: actions/upload-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_${{ matrix.test-file }}_duplicates_json
+          path: ./test-suite/alt_e2eshark/duplicates.json
 
-  upload_artifacts:
+  push_artifacts:
     needs: [e2eshark]
-    runs-on: nodai-amdgpu-mi250-x86-64
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - name: merge_rocm_reports
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            regression-blob: rocm
+          - name: merge_cpu_reports
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: llvm-cpu
+            regression-blob: cpu
+    env:
+      AZ_PUBLIC_KEY: ${{ secrets.SHARKPUBLIC_AZ_PUBLIC_KEY }}
     steps:
+      - name: Checkout Test Suite
+        uses: actions/checkout@v2
+        with:
+          repository: nod-ai/SHARK-TestSuite
+          ref: alt-merge-reports
+          path: test-suite
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           repository: nod-ai/e2eshark-reports
-          ref: 'main'
+          ref: main
           token: ${{ secrets.E2ESHARK_GITHUB_TOKEN }}
           path: e2eshark-reports
-      
+      - name: "Setup alt test suite venv"
+        run: |
+          python3.11 -m venv report_venv_alt
+          source report_venv_alt/bin/activate
+          pip install --upgrade pip
+          pip install -r ./test-suite/alt_e2eshark/base_requirements.txt
+          pip install -r ./test-suite/alt_e2eshark/iree_requirements.txt
+          pip install --no-deps -r ./test-suite/alt_e2eshark/torch_mlir_requirements.txt
+          pip install --find-links https://iree.dev/pip-release-links.html iree-compiler iree-runtime --upgrade
       - uses: actions/download-artifact@master
         with:
-          name: ci_reports
-          path: ./e2eshark-reports
-
-      - name: Push artifacts
+          name: ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_migraphx_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_migraphx_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_migraphx_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_migraphx_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard1_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard1_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard1_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard1_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard2_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard2_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard2_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard2_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard3_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard3_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_nlp-shard3_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard3_onnx_json
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_onnxrt-iree-ep_onnx_md
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_onnxrt-iree-ep_onnx_md
+      # - uses: actions/download-artifact@master
+      #   with:
+      #     name: ci_reports_${{ matrix.backend }}_onnxrt-iree-ep_onnx_json
+      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_onnxrt-iree-ep_onnx_json
+      - name: Merge Reports
         run: |
-          date=$(date '+%Y-%m-%d')
+          source report_venv_alt/bin/activate
+
+          python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
+          --sources ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_json/vai-int8-p0p1-shard1.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_json/vai-int8-p0p1-shard2.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_json/vai-int8-p0p1-shard3.json \
+          --output ./e2eshark-reports/vai-int8-p0p1.json \
+          --report --report-file ./e2eshark-reports/vai-int8-p0p1.md
+
+          python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
+          --sources ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard1_onnx_json/nlp-shard1.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard2_onnx_json/nlp-shard2.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_nlp-shard3_onnx_json/nlp-shard3.json \
+          --output ./e2eshark-reports/nlp.json \
+          --report --report-file ./e2eshark-reports/nlp.md
+
+          python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
+          --sources ./e2eshark-reports/vai-int8-p0p1.json \
+          ./e2eshark-reports/nlp.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json/shark-test-suite.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_json/vai-vision-int8.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_migraphx_onnx_json/migraphx.json \
+          --output ./e2eshark-reports/combined_reports.json \
+          --report --report-file ./e2eshark-reports/combined_reports.md
+
+      - name: Push status artifacts
+        run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
+          git pull
+          date=$(date '+%Y-%m-%d')
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-int8-p0p1
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/shark-test-suite
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-vision-int8
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/migraphx
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/nlp
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/combined-reports
+          cp vai-int8-p0p1.md ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-int8-p0p1/summary.md
+          cp nlp.md ${date}/ci_reports_onnx/${{ matrix.backend }}/nlp/summary.md
+          cp ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_md/shark-test-suite.md ${date}/ci_reports_onnx/${{ matrix.backend }}/shark-test-suite/summary.md
+          cp ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_md/vai-vision-int8.md ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-vision-int8/summary.md
+          cp ci_reports_${{ matrix.backend }}_migraphx_onnx_md/migraphx.md ${date}/ci_reports_onnx/${{ matrix.backend }}/migraphx/summary.md
+          cp combined_reports.md ${date}/ci_reports_onnx/${{ matrix.backend }}/combined-reports/summary.md
           git add $date
-          git commit -m "add CI reports for e2eshark"
+          git commit -m "add CI status reports for e2eshark for ${{ matrix.backend }}"
+          git push origin main
+        working-directory: ./e2eshark-reports
+      
+      - name: Regression Reports
+        run: |
+          source report_venv_alt/bin/activate
+          cd test-suite
+          mkdir latest
+          mkdir baseline
+          wget https://sharkpublic.blob.core.windows.net/sharkpublic/latest-test-suite/combined_reports_${{ matrix.regression-blob }}.json -O latest/combined_reports_${{ matrix.backend }}.json
+          wget https://sharkpublic.blob.core.windows.net/sharkpublic/baseline-test-suite/combined_reports_${{ matrix.regression-blob }}.json -O baseline/combined_reports_${{ matrix.backend }}.json
+          cd ..
+
+          python ./test-suite/alt_e2eshark/utils/check_regressions.py \
+            --new ./e2eshark-reports/combined_reports.json \
+            --old ./test-suite/latest/combined_reports_${{ matrix.backend }}.json \
+            --report-file ./e2eshark-reports/yesterday_comparison.md \
+            --perf_tol_regression=0.05 \
+            --perf_tol_progression=0.05
+          
+          python ./test-suite/alt_e2eshark/utils/check_regressions.py \
+            --new ./e2eshark-reports/combined_reports.json \
+            --old ./test-suite/baseline/combined_reports_${{ matrix.backend }}.json \
+            --report-file ./e2eshark-reports/baseline_comparison.md \
+            --perf_tol_regression=0.1 \
+            --perf_tol_progression=0.1
+          
+          az storage blob upload --account-name sharkpublic --container-name sharkpublic \
+            --name latest-test-suite/combined_reports_${{ matrix.backend }}.json \
+            --file ./e2eshark-reports/combined_reports.json \
+            --account-key ${AZ_PUBLIC_KEY} --overwrite
+
+      - name: Push regression artifacts
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git pull
+          date=$(date '+%Y-%m-%d')
+          cp yesterday_comparison.md ${date}/ci_reports_onnx/${{ matrix.backend }}/combined-reports/yesterday_comparison.md
+          cp baseline_comparison.md ${date}/ci_reports_onnx/${{ matrix.backend }}/combined-reports/baseline_comparison.md
+          git add $date
+          git commit -m "add CI regression reports for e2eshark for ${{ matrix.backend }}"
           git push origin main
         working-directory: ./e2eshark-reports

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -48,27 +48,27 @@ jobs:
             target-chip: gfx942
             test-file: shark-test-suite
             cache-dir: /data/e2eshark/shark-test-suite-models-cache
-          # - name: mi300_gpu5_test
-          #   runs-on: nodai-amdgpu-mi300-x86-64
-          #   backend: rocm
-          #   device: hip
-          #   target-chip: gfx942
-          #   test-file: vai-hf-cnn-fp32-shard1
-          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
-          # - name: mi300_gpu6_test
-          #   runs-on: nodai-amdgpu-mi300-x86-64
-          #   backend: rocm
-          #   device: hip
-          #   target-chip: gfx942
-          #   test-file: vai-hf-cnn-fp32-shard2
-          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
-          # - name: mi300_gpu7_test
-          #   runs-on: nodai-amdgpu-mi300-x86-64
-          #   backend: rocm
-          #   device: hip
-          #   target-chip: gfx942
-          #   test-file: vai-hf-cnn-fp32-shard3
-          #   cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu5_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-hf-cnn-fp32-shard1
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu6_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-hf-cnn-fp32-shard2
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
+          - name: mi300_gpu7_test
+            runs-on: nodai-amdgpu-mi300-x86-64
+            backend: rocm
+            device: hip
+            target-chip: gfx942
+            test-file: vai-hf-cnn-fp32-shard3
+            cache-dir: /data/e2eshark/shark-test-suite-models-cache
           - name: mi300_gpu8_test
             runs-on: nodai-amdgpu-mi300-x86-64
             backend: rocm
@@ -139,27 +139,27 @@ jobs:
             target-chip: x86_64-linux-gnu
             test-file: shark-test-suite
             cache-dir: /home/sai/test-suite-ci-cache
-          # - name: cpu_shard5_test
-          #   runs-on: nodai-amdgpu-mi250-x86-64
-          #   backend: llvm-cpu
-          #   device: local-task
-          #   target-chip: x86_64-linux-gnu
-          #   test-file: vai-hf-cnn-fp32-shard1
-          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
-          # - name: cpu_shard6_test
-          #   runs-on: nodai-amdgpu-mi250-x86-64
-          #   backend: llvm-cpu
-          #   device: local-task
-          #   target-chip: x86_64-linux-gnu
-          #   test-file: vai-hf-cnn-fp32-shard2
-          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
-          # - name: cpu_shard7_test
-          #   runs-on: nodai-amdgpu-mi250-x86-64
-          #   backend: llvm-cpu
-          #   device: local-task
-          #   target-chip: x86_64-linux-gnu
-          #   test-file: vai-hf-cnn-fp32-shard3
-          #   cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          - name: cpu_shard5_test
+            runs-on: nodai-amdgpu-mi250-x86-64
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-hf-cnn-fp32-shard1
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          - name: cpu_shard6_test
+            runs-on: nodai-amdgpu-mi250-x86-64
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-hf-cnn-fp32-shard2
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
+          - name: cpu_shard7_test
+            runs-on: nodai-amdgpu-mi250-x86-64
+            backend: llvm-cpu
+            device: local-task
+            target-chip: x86_64-linux-gnu
+            test-file: vai-hf-cnn-fp32-shard3
+            cache-dir: /groups/aig_sharks/test-suite-ci-cache
           - name: cpu_shard8_test
             runs-on: large-cpu
             backend: llvm-cpu
@@ -373,30 +373,30 @@ jobs:
         with:
           name: ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json
           path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
-      # - uses: actions/download-artifact@master
-      #   with:
-      #     name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
-      #     path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_md
+      - uses: actions/download-artifact@master
+        with:
+          name: ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
+          path: ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json
       - uses: actions/download-artifact@master
         with:
           name: ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_md
@@ -474,6 +474,13 @@ jobs:
           source report_venv_alt/bin/activate
 
           python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
+          --sources ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard1_onnx_json/vai-hf-cnn-fp32-shard1.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard2_onnx_json/vai-hf-cnn-fp32-shard2.json \
+          ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-hf-cnn-fp32-shard3_onnx_json/vai-hf-cnn-fp32-shard3.json \
+          --output ./e2eshark-reports/vai-hf-cnn-fp32.json \
+          --report --report-file ./e2eshark-reports/vai-hf-cnn-fp32.md
+
+          python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
           --sources ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard1_onnx_json/vai-int8-p0p1-shard1.json \
           ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard2_onnx_json/vai-int8-p0p1-shard2.json \
           ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-int8-p0p1-shard3_onnx_json/vai-int8-p0p1-shard3.json \
@@ -489,6 +496,7 @@ jobs:
 
           python ./test-suite/alt_e2eshark/utils/merge_dicts.py \
           --sources ./e2eshark-reports/vai-int8-p0p1.json \
+          ./e2eshark-reports/vai-hf-cnn-fp32.json \
           ./e2eshark-reports/nlp.json \
           ./e2eshark-reports/ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_json/shark-test-suite.json \
           ./e2eshark-reports/ci_reports_${{ matrix.backend }}_vai-vision-int8_onnx_json/vai-vision-int8.json \
@@ -502,12 +510,14 @@ jobs:
           git config user.email "<>"
           git pull
           date=$(date '+%Y-%m-%d')
+          mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-hf-cnn-fp32
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-int8-p0p1
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/shark-test-suite
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-vision-int8
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/migraphx
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/nlp
           mkdir -p ${date}/ci_reports_onnx/${{ matrix.backend }}/combined-reports
+          cp vai-hf-cnn-fp32.md ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-hf-cnn-fp32/summary.md
           cp vai-int8-p0p1.md ${date}/ci_reports_onnx/${{ matrix.backend }}/vai-int8-p0p1/summary.md
           cp nlp.md ${date}/ci_reports_onnx/${{ matrix.backend }}/nlp/summary.md
           cp ci_reports_${{ matrix.backend }}_shark-test-suite_onnx_md/shark-test-suite.md ${date}/ci_reports_onnx/${{ matrix.backend }}/shark-test-suite/summary.md

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -255,7 +255,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
-            -t ${{ matrix.target-chip }} \
+            -c ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --mode=cl-onnx-iree \
             --cleanup=3 \
@@ -278,7 +278,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
-            -t ${{ matrix.target-chip }} \
+            -c ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --mode=cl-onnx-iree \
             --cleanup=3 \
@@ -304,7 +304,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
-            -t ${{ matrix.target-chip }} \
+            -c ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --cleanup=3 \
             --get-metadata \

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: alt-merge-reports
+          ref: alt-e2eshark
           path: test-suite
       
       - name: "Setup alt e2eshark python venv"
@@ -347,7 +347,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nod-ai/SHARK-TestSuite
-          ref: alt-merge-reports
+          ref: alt-e2eshark
           path: test-suite
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test_e2eshark.yml
+++ b/.github/workflows/test_e2eshark.yml
@@ -255,6 +255,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
+            -t ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --mode=cl-onnx-iree \
             --cleanup=3 \
@@ -277,6 +278,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
+            -t ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --mode=cl-onnx-iree \
             --cleanup=3 \
@@ -302,6 +304,7 @@ jobs:
             --testsfile onnx_tests/models/external_lists/${{ matrix.test-file }}.txt \
             -b ${{ matrix.backend }} \
             -d ${{ matrix.device }} \
+            -t ${{ matrix.target-chip }} \
             --report-file reports/${{ matrix.test-file }}.md \
             --cleanup=3 \
             --get-metadata \

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -88,11 +88,11 @@ class CLIREEBackend(BackendBase):
                 else:
                     self.extra_args.append("--" + a)
         if hal_target_backend == "rocm":
-            self.extra_args = [
+            self.extra_args += [
                 f"--iree-hip-target={self.target_chip}",
             ]
         if hal_target_backend == "llvm-cpu":
-            self.extra_args = [
+            self.extra_args += [
                 "--iree-llvmcpu-target-cpu=host",
             ]
     

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -87,11 +87,11 @@ class CLIREEBackend(BackendBase):
                     self.extra_args.append(a)
                 else:
                     self.extra_args.append("--" + a)
-        elif hal_target_backend == "rocm":
+        if hal_target_backend == "rocm":
             self.extra_args = [
                 f"--iree-hip-target={self.target_chip}",
             ]
-        elif hal_target_backend == "llvm-cpu":
+        if hal_target_backend == "llvm-cpu":
             self.extra_args = [
                 "--iree-llvmcpu-target-cpu=host",
             ]

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -86,6 +86,28 @@ class CLIREEBackend(BackendBase):
                     self.extra_args.append(a)
                 else:
                     self.extra_args.append("--" + a)
+        elif hal_target_backend == "rocm":
+            # some extra args for Mi300x - some of these may not work for other chips
+            self.extra_args = [
+                "--iree-hip-target=gfx942",
+                # "--iree-global-opt-propagate-transposes=true",
+                # "--iree-opt-outer-dim-concat=true",
+                # "--iree-opt-const-eval=false",
+                # "--iree-rocm-waves-per-eu=2",
+                # "--iree-llvmgpu-enable-prefetch",
+                # "--iree-flow-enable-aggressive-fusion",
+                # "--iree-flow-enable-fuse-horizontal-contractions=true",
+                # "--iree-opt-aggressively-propagate-transposes=true",
+                # "--iree-codegen-llvmgpu-use-vector-distribution=true",
+                # "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-preprocessing-pad-to-intrinsics{pad-target-type=conv}))",
+                # maybe add iree-preprocessing-transpose-convolution-pipeline to preprocessing pipeline.
+            ]
+        elif hal_target_backend == "llvm-cpu":
+            self.extra_args = [
+                "--iree-llvmcpu-target-cpu=host",
+                # "--iree-llvmcpu-fail-on-large-vector=0",
+                # "--iree-llvmcpu-stack-allocation-limit=300000",
+            ]
     
     def compile(self, module_path: str, *, save_to : str = None) -> str:
         vmfb_path = os.path.join(save_to, "compiled_model.vmfb")

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -76,9 +76,10 @@ class SimpleIREEBackend(BackendBase):
 
 class CLIREEBackend(BackendBase):
     '''This backend calls iree through the command line to compile and run MLIR modules'''
-    def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", extra_args : List[str] = None):
+    def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", target_chip = None, extra_args : List[str] = None):
         self.device = device
         self.hal_target_backend = hal_target_backend
+        self.target_chip = target_chip
         self.extra_args = []
         if extra_args:
             for a in extra_args:
@@ -87,26 +88,12 @@ class CLIREEBackend(BackendBase):
                 else:
                     self.extra_args.append("--" + a)
         elif hal_target_backend == "rocm":
-            # some extra args for Mi300x - some of these may not work for other chips
             self.extra_args = [
-                "--iree-hip-target=gfx942",
-                # "--iree-global-opt-propagate-transposes=true",
-                # "--iree-opt-outer-dim-concat=true",
-                # "--iree-opt-const-eval=false",
-                # "--iree-rocm-waves-per-eu=2",
-                # "--iree-llvmgpu-enable-prefetch",
-                # "--iree-flow-enable-aggressive-fusion",
-                # "--iree-flow-enable-fuse-horizontal-contractions=true",
-                # "--iree-opt-aggressively-propagate-transposes=true",
-                # "--iree-codegen-llvmgpu-use-vector-distribution=true",
-                # "--iree-preprocessing-pass-pipeline=builtin.module(util.func(iree-preprocessing-pad-to-intrinsics{pad-target-type=conv}))",
-                # maybe add iree-preprocessing-transpose-convolution-pipeline to preprocessing pipeline.
+                f"--iree-hip-target={self.target_chip}",
             ]
         elif hal_target_backend == "llvm-cpu":
             self.extra_args = [
                 "--iree-llvmcpu-target-cpu=host",
-                # "--iree-llvmcpu-fail-on-large-vector=0",
-                # "--iree-llvmcpu-stack-allocation-limit=300000",
             ]
     
     def compile(self, module_path: str, *, save_to : str = None) -> str:

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -101,7 +101,7 @@ def main(args):
     elif args.mode == "cl-onnx-iree":
         pipeline = REDUCE_TO_LINALG_PIPELINE if args.torchtolinalg else []
         config = CLOnnxTestConfig(
-            str(TEST_DIR), CLIREEBackend(device=args.device, hal_target_backend=args.backend, target_chip=args.target, extra_args=args.iree_compile_args), pipeline
+            str(TEST_DIR), CLIREEBackend(device=args.device, hal_target_backend=args.backend, target_chip=args.target_chip, extra_args=args.iree_compile_args), pipeline
         )
     elif args.mode == "ort-ep":
         # TODO: allow specifying provider explicitly from cl args.
@@ -332,7 +332,7 @@ def _get_argparse():
         help="specifies the iree-hal-target-device / iree-hal-target-backends for compile phase",
     )
     parser.add_argument(
-        "-t",
+        "-c",
         "--target-chip",
         default="gfx942",
         help="specifies the target chip (gfx942 for hip)",

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -101,7 +101,7 @@ def main(args):
     elif args.mode == "cl-onnx-iree":
         pipeline = REDUCE_TO_LINALG_PIPELINE if args.torchtolinalg else []
         config = CLOnnxTestConfig(
-            str(TEST_DIR), CLIREEBackend(device=args.device, hal_target_backend=args.backend, extra_args=args.iree_compile_args), pipeline
+            str(TEST_DIR), CLIREEBackend(device=args.device, hal_target_backend=args.backend, target_chip=args.target, extra_args=args.iree_compile_args), pipeline
         )
     elif args.mode == "ort-ep":
         # TODO: allow specifying provider explicitly from cl args.
@@ -330,6 +330,12 @@ def _get_argparse():
         choices=["llvm-cpu", "amd-aie", "rocm", "hip", "cuda", "vmvx", "metal-spirv", "vulkan-spirv"],
         default="llvm-cpu",
         help="specifies the iree-hal-target-device / iree-hal-target-backends for compile phase",
+    )
+    parser.add_argument(
+        "-t",
+        "--target-chip",
+        default="gfx942",
+        help="specifies the target chip (gfx942 for hip)",
     )
     parser.add_argument(
         "-ica",


### PR DESCRIPTION
This pulls in the required changes to run nightly CI for alt e2eshark.

Few things to iterate on here:

- Figure out a way to run a loop/matrix on a step so we don't have a bunch of download commands in push artifact step
- Figure out how to not fail the download artifact step if an artifact for a certain shard is not available
- Pull the merge report script calls, creating directories, copy pasting artifacts to eventually push into the reports repo into a python script that won't fail if certain shards fail and are not available

Just merging this in so we have a nightly going that doesn't depend on manual triggers. We can iterate on it. Has been running fine for the last week.