### PR TITLE
add seven compile failure models to basic opt list

### DIFF
--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -42,6 +42,7 @@ no_opset_update = [
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:
 basic_opt = [
+    "bat_resnext26ts.ch_in1k",
     "twins_svt_base",
     "twins_svt_large",
     "twins_svt_small",

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -42,6 +42,9 @@ no_opset_update = [
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:
 basic_opt = [
+    "jx_nest_base",
+    "jx_nest_small",
+    "jx_nest_tiny",
     "coat_mini",
     "coat_tiny",
     "mvitv2_base",

--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -42,6 +42,9 @@ no_opset_update = [
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:
 basic_opt = [
+    "twins_svt_base",
+    "twins_svt_large",
+    "twins_svt_small",
     "jx_nest_base",
     "jx_nest_small",
     "jx_nest_tiny",


### PR DESCRIPTION
1. Three `jx_nest_*` models will newly pass with basic optimizations. 
2. Three `twins_svt_*` models will now pass iree inference invocation, but fail numerics quite terribly. 
3. The `bat_resnext` model will still fail compile due to a similar error as in <https://github.com/iree-org/iree/issues/19058>