### PR TITLE
Update opset version without weights for large nlp models

### DIFF
--- a/alt_e2eshark/onnx_tests/models/azure_models.py
+++ b/alt_e2eshark/onnx_tests/models/azure_models.py
@@ -31,13 +31,15 @@ no_opset_update = [
     "dm_nfnet_f2.dm_in1k",
     # getting test runner crash for the following.
     # TODO: unblock these when we externalize weights on import
-    # "dm_nfnet_f3.dm_in1k",
-    # "dm_nfnet_f4.dm_in1k",
+    "dm_nfnet_f3.dm_in1k",
+    "dm_nfnet_f4.dm_in1k",
     "vit_base_r50_s16_384.orig_in21k_ft_in1k",
     "vit_small_r26_s32_224.augreg_in21k_ft_in1k",
     "vit_small_r26_s32_384.augreg_in21k_ft_in1k",
     "vit_tiny_r_s16_p8_224.augreg_in21k_ft_in1k",
     "vit_tiny_r_s16_p8_384.augreg_in21k_ft_in1k",
+    "vit_large_r50_s32_224.augreg_in21k_ft_in1k",
+    "vit_large_r50_s32_384.augreg_in21k_ft_in1k",
 ]
 
 # if the model has significant shape issues, consider applying basic optimizations before import by adding to this list:

--- a/alt_e2eshark/onnx_tests/models/nlp.py
+++ b/alt_e2eshark/onnx_tests/models/nlp.py
@@ -79,7 +79,7 @@ def dim_param_constructor(dim_param_dict):
                 self.opset_version = None
             # TODO: check opset versions
             # print(f"Opset: {self.opset_version}")
-            self.update_opset_version_and_overwrite()
+            # self.update_opset_version_and_overwrite()
 
         def update_no_ext(self):
             """Models larger than 2GB do not allow updating opset version, so we update opset version without loading external data. Unfortunately, all external data references get wiped, and we need to manually trace through the graph and copy them back in."""


### PR DESCRIPTION
We also need the importer change from <https://github.com/llvm/torch-mlir/pull/3875> for these to work. The primary issue is that updating the opset version requires the model to be smaller than 2GB. I've found a hacky way to update the opset version without loading external data, and this is the result.

## Passing Summary

**TOTAL TESTS = 49**
|Stage|# Passing|% of Total|% of Attempted|
|--|--|--|--|
| Setup | 49 | 100.0% | 100.0% |
| IREE Compilation | 41 | 83.7% | 83.7% |
| Gold Inference | 41 | 83.7% | 100.0% |
| IREE Inference Invocation | 41 | 83.7% | 100.0% |
| Inference Comparison (PASS) | 31 | 63.3% | 75.6% |
## Fail Summary

**TOTAL TESTS = 49**
|Stage|# Failed at Stage|% of Total|
|--|--|--|
| Setup | 0 | 0.0% |
| IREE Compilation | 8 | 16.3% |
| Gold Inference | 0 | 0.0% |
| IREE Inference Invocation | 0 | 0.0% |
| Inference Comparison | 10 | 20.4% |
## Test Run Detail
Test was run with the following arguments:
Namespace(device='local-task', backend='llvm-cpu', target_chip='gfx942', iree_compile_args=None, mode='cl-onnx-iree', torchtolinalg=False, stages=None, skip_stages=None, benchmark=False, load_inputs=False, groups='all', test_filter=None, testsfile='import.txt', tolerance=None, verbose=True, rundirectory='test-run', no_artifacts=False, cleanup='3', report=True, report_file='import.md', get_metadata=True)

| Test | Exit Status | Mean Benchmark Time (ms) | Notes |
|--|--|--|--|
| dm_nfnet_f3.dm_in1k | PASS | None | |
| dm_nfnet_f4.dm_in1k | PASS | None | |
| migraphx_sd__unet__model | compilation | None | |
| migraphx_sdxl__unet__model | compilation | None | |
| model--financial-summarization-pegasus--human-centered-summarization | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.0001_pretrainedTrue_epochs1--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.001_pretrainedTrue_epochs1--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.001_pretrainedTrue_epochs2--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.001_pretrainedTrue_epochs3--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.01--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.01_pretrainedFalse_epochs10--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.01_pretrainedTrue_epochs1--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.05--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.0_pretrainedFalse--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.1_pretrainedFalse_epochs10--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.1_pretrainedTrue_epochs1--jhaochenz | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.2--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.5--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.5_pretrainedFalse--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.8--yuhuizhang | PASS | None | |
| model--finetuned_gpt2-large_sst2_negation0.8_pretrainedFalse--yuhuizhang | PASS | None | |
| model--flan-t5-large-samsum--oguuzhansahin | Numerics | None | |
| model--long-t5-tglobal-large-pubmed-3k-booksum-16384-WIP--pszemraj | compilation | None | |
| model--long-t5-tglobal-large-pubmed-3k-booksum-16384-WIP13--pszemraj | compilation | None | |
| model--long-t5-tglobal-large-pubmed-3k-booksum-16384-WIP14--pszemraj | compilation | None | |
| model--long-t5-tglobal-large-pubmed-3k-booksum-16384-WIP15--pszemraj | compilation | None | |
| model--long-t5-tglobal-large-pubmed-3k-booksum-16384-WIP17--pszemraj | compilation | None | |
| model--m2m100_418M-finetuned-kde4-en-to-pt_BR--danhsf | PASS | None | |
| model--m2m100_418M-fr--Jour | PASS | None | |
| model--m2m100_418M-fr--NDugar | PASS | None | |
| model--m2m100_418M-ja--vivek-307306 | Numerics | None | |
| model--manifestoberta-xlm-roberta-56policy-topics-sentence-2023-1-1--manifesto-project | Numerics | None | |
| model--mT5-base-HunSum-1--SZTAKI-HLT | Numerics | None | |
| model--mT5_multilingual_XLSum--csebuetnlp | Numerics | None | |
| model--my_xlm-roberta-large-finetuned-conll03--BahAdoR0101 | Numerics | None | |
| model--pegasus-cnn_dailymail--google | PASS | None | |
| model--pegasus-large-book-summary--pszemraj | PASS | None | |
| model--pegasus-large-booksum--cnicu | PASS | None | |
| model--pegasus-large-summary-explain--pszemraj | PASS | None | |
| model--pegasus-xsum--google | PASS | None | |
| model--pegasus_summarizer--tuner007 | PASS | None | |
| model--roberta-ner-multilingual--julian-schelb | Numerics | None | |
| model--t5-large-finetuned-xsum-cnn--sysresearch101 | Numerics | None | |
| model--tglobal-large-booksum-WIP4-r1--pszemraj | compilation | None | |
| model--xlm-roberta-large-squad2--deepset | Numerics | None | |
| model--xlmr-large-qa-fa--m3hrdadfi | Numerics | None | |
| model--YuisekinAI-mistral-0.7B--yuiseki | PASS | None | |
| vit_large_r50_s32_224.augreg_in21k_ft_in1k | PASS | None | |
| vit_large_r50_s32_384.augreg_in21k_ft_in1k | PASS | None | |
