### PR TITLE
Replace string concatenated paths by os.path.join()

### DIFF
--- a/alt_e2eshark/e2e_testing/storage.py
+++ b/alt_e2eshark/e2e_testing/storage.py
@@ -204,7 +204,7 @@ class TestTensors:
         tensor_list = []
         pb_input_files = glob.glob("input_?.pb", root_dir=dir_path)
         if len(pb_input_files) > 0:
-            onnx_tensor_list = [onnx.load_tensor(dir_path + '/' + tensor) for tensor in pb_input_files]
+            onnx_tensor_list = [onnx.load_tensor(os.path.join(dir_path, tensor)) for tensor in pb_input_files]
             for tensor in onnx_tensor_list:
                 tensor_list.append(onnx.numpy_helper.to_array(tensor, base_dir=dir_path))
         else:

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -53,13 +53,13 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
 
     def download_model_yaml(self, model_url: str):
         # The cache dir should already have model.onnx
-        if not os.path.exists(self.cache_dir + "/turnkey_stats.yaml"):
+        if not os.path.exists(os.path.join(self.cache_dir, "turnkey_stats.yaml")):
             turnkey_yaml_url = '/'.join(model_url.split('/')[:-1]) + '/turnkey_stats.yaml'
             content = requests.get(turnkey_yaml_url).content
-            with open(self.cache_dir + "/turnkey_stats.yaml", "wb") as out_file:
+            with open(os.path.join(self.cache_dir, "turnkey_stats.yaml"), "wb") as out_file:
                 out_file.write(content)
 
-        shutil.copy(self.cache_dir + "/model.onnx", str(Path(self.model).parent))
+        shutil.copy(os.path.join(self.cache_dir, "model.onnx"), str(Path(self.model).parent))
 
     def contruct_input_name_to_shape_map(self):
         turnkey_dict = {}


### PR DESCRIPTION
To remove inconsistencies across different Python versions and have uniform behavior, replace all file paths constructed by string concatenation with a call to `os.path.join()`.