### PR TITLE
Add Flux_1.dev transformer and text encoder tests

### DIFF
--- a/alt_e2eshark/base_requirements.txt
+++ b/alt_e2eshark/base_requirements.txt
@@ -6,6 +6,7 @@ ml_dtypes
 onnx
 onnxruntime
 transformers
+diffusers
 huggingface-hub
 sentencepiece
 accelerate

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -7,7 +7,7 @@ import abc
 import onnxruntime as ort
 from typing import TypeVar, List
 from e2e_testing.storage import TestTensors, get_shape_string
-from e2e_testing.framework import CompiledOutput, ModelArtifact
+from e2e_testing.framework import CompiledOutput, ModelArtifact, CompilerOptions, RuntimeOptions
 from onnx import ModelProto
 import os
 from pathlib import Path
@@ -18,11 +18,11 @@ Invoker = TypeVar("Invoker")
 class BackendBase(abc.ABC):
 
     @abc.abstractmethod
-    def compile(self, module: ModelArtifact) -> CompiledOutput:
+    def compile(self, module: ModelArtifact, extra_options : CompilerOptions) -> CompiledOutput:
         """specifies how to compile an MLIR Module"""
 
     @abc.abstractmethod
-    def load(self, artifact: CompiledOutput, func_name: str) -> Invoker:
+    def load(self, artifact: CompiledOutput, func_name: str, extra_options : RuntimeOptions) -> Invoker:
         """loads the function with name func_name from compiled artifact. This method should return a function callable from python."""
 
 
@@ -30,6 +30,11 @@ from iree import compiler as ireec
 from iree import runtime as ireert
 
 
+def flag(arg : str) -> str:
+    if arg.startswith("--"):
+        return arg
+    else:
+        return f'--{arg}'
 class SimpleIREEBackend(BackendBase):
     '''This backend uses iree to compile and run MLIR modules for a specified hal_target_backend'''
     def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", extra_args : List[str] = None):
@@ -38,17 +43,18 @@ class SimpleIREEBackend(BackendBase):
         self.extra_args = []
         if extra_args:
             for a in extra_args:
-                if a[0:2] == "--":
-                    self.extra_args.append(a)
-                else:
-                    self.extra_args.append("--" + a)
+                self.extra_args.append(flag(a))
 
-    def compile(self, module, *, save_to: str = None):
+    def compile(self, module, *, save_to: str = None, extra_options : CompilerOptions):
+        test_specific_args = extra_options.common_extra_args
+        if self.hal_target_backend in extra_options.backend_specific_flags.keys():
+            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
+        compile_args = self.extra_args + [flag(arg) for arg in test_specific_args]
         # compile to a vmfb for llvm-cpu
         b = ireec.tools.compile_str(
             str(module),
             target_backends=[self.hal_target_backend],
-            extra_args=self.extra_args,
+            extra_args=compile_args,
         )
         # log the vmfb
         if save_to:
@@ -56,7 +62,7 @@ class SimpleIREEBackend(BackendBase):
                 f.write(b)
         return b
 
-    def load(self, artifact, *, func_name="main"):
+    def load(self, artifact, *, func_name="main", extra_options : RuntimeOptions):
         config = ireert.Config(self.device)
         ctx = ireert.SystemContext(config=config)
         vm_module = ireert.VmModule.copy_buffer(ctx.instance, artifact)
@@ -96,12 +102,15 @@ class CLIREEBackend(BackendBase):
                 "--iree-llvmcpu-target-cpu=host",
             ]
     
-    def compile(self, module_path: str, *, save_to : str = None) -> str:
+    def compile(self, module_path: str, *, save_to : str = None, extra_options : CompilerOptions) -> str:
+        test_specific_args = extra_options.common_extra_args
+        if self.hal_target_backend in extra_options.backend_specific_flags.keys():
+            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
+        compile_args = self.extra_args + [flag(arg) for arg in test_specific_args]
         vmfb_path = os.path.join(save_to, "compiled_model.vmfb")
         arg_string = f"--iree-hal-target-backends={self.hal_target_backend} "
-        for arg in self.extra_args:
-            arg_string += arg
-            arg_string += " "
+        for arg in compile_args:
+            arg_string += f'{arg} '
         detail_log = os.path.join(save_to, "detail", "compilation.detail.log")
         commands_log = os.path.join(save_to, "commands", "compilation.commands.log")
         script = f"iree-compile {module_path} {arg_string}-o {vmfb_path} 1> {detail_log} 2>&1"
@@ -116,16 +125,21 @@ class CLIREEBackend(BackendBase):
             raise FileNotFoundError(error_msg)
         return vmfb_path
     
-    def load(self, vmfb_path: str, *, func_name=None):
+    def load(self, vmfb_path: str, *, func_name=None, extra_options : RuntimeOptions):
         """A bit hacky. func returns a script that would dump outputs to terminal output. Modified in config.run method"""
+        test_specific_args = extra_options.common_extra_args
+        if self.hal_target_backend in extra_options.backend_specific_flags.keys():
+            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
         run_dir = Path(vmfb_path).parent
         def func(x: TestTensors) -> str:
-            script = f"iree-run-module --module='{vmfb_path}' --device={self.device}"
+            script = f"iree-run-module --module='{vmfb_path}' --device={self.device} "
+            for arg in test_specific_args:
+                script += f'{flag(arg)} '
             if func_name:
-                script += f" --function='{func_name}'"
+                script += f"--function='{func_name}' "
             torch_inputs = x.to_torch().data
             for index, input in enumerate(torch_inputs):
-                script += f" --input='{get_shape_string(input)}=@{run_dir}/input.{index}.bin'"
+                script += f"--input='{get_shape_string(input)}=@{run_dir}/input.{index}.bin' "
             return script
         return func
             
@@ -136,12 +150,7 @@ class OnnxrtIreeEpBackend(BackendBase):
         self.device = device
         self.hal_target_device = hal_target_device
         if extra_args:
-            self.extra_args = []
-            for a in extra_args:
-                if a[0:2] == "--":
-                    self.extra_args.append(a)
-                else:
-                    self.extra_args.append("--" + a)
+            self.extra_args = [flag(a) for a in extra_args]
         elif hal_target_device == "hip":
             # some extra args for Mi250 - some of these may not work for other chips
             self.extra_args = [
@@ -159,7 +168,7 @@ class OnnxrtIreeEpBackend(BackendBase):
         #  sess_opt.log_verbosity_level = 0
         #  self.sess_opt.log_severity_level = 0
 
-    def compile(self, model: ModelProto, *, save_to: str = None) -> ort.InferenceSession:
+    def compile(self, model: ModelProto, *, save_to: str = None, extra_options : CompilerOptions) -> ort.InferenceSession:
         if self.provider_options:
             provider_options_dict = self.provider_options[0]
             provider_options_dict["save_to"] = save_to
@@ -173,7 +182,7 @@ class OnnxrtIreeEpBackend(BackendBase):
         # can't save an onnx runtime session
         return session
 
-    def load(self, session: ort.InferenceSession, *, func_name=None) -> Invoker:
+    def load(self, session: ort.InferenceSession, *, func_name=None, extra_options : RuntimeOptions) -> Invoker:
         def func(x: TestTensors):
             data = x.to_numpy().data
             session_inputs = session.get_inputs()

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -34,20 +34,26 @@ def flag(arg : str) -> str:
     if arg.startswith("--"):
         return arg
     return f'--{arg}'
+
 class SimpleIREEBackend(BackendBase):
     '''This backend uses iree to compile and run MLIR modules for a specified hal_target_backend'''
     def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", extra_args : List[str] = None):
         self.device = device
         self.hal_target_backend = hal_target_backend
-        self.extra_args = []
-        if extra_args:
-            for a in extra_args:
-                self.extra_args.append(flag(a))
+        self.extra_args = [] if extra_args is None else [flag(a) for a in extra_args]
+        if hal_target_backend == "rocm":
+            self.extra_args += [
+                f"--iree-hip-target={self.target_chip}",
+            ]
+        if hal_target_backend == "llvm-cpu":
+            self.extra_args += [
+                "--iree-llvmcpu-target-cpu=host",
+            ]
 
     def compile(self, module, *, save_to: str = None, extra_options : CompilerOptions):
-        test_specific_args = extra_options.common_extra_args
+        test_specific_args = list(extra_options.common_extra_args)
         if self.hal_target_backend in extra_options.backend_specific_flags.keys():
-            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
+            test_specific_args += list(extra_options.backend_specific_flags[self.hal_target_backend])
         compile_args = self.extra_args + [flag(arg) for arg in test_specific_args]
         # compile to a vmfb for llvm-cpu
         b = ireec.tools.compile_str(
@@ -85,13 +91,7 @@ class CLIREEBackend(BackendBase):
         self.device = device
         self.hal_target_backend = hal_target_backend
         self.target_chip = target_chip
-        self.extra_args = []
-        if extra_args:
-            for a in extra_args:
-                if a[0:2] == "--":
-                    self.extra_args.append(a)
-                else:
-                    self.extra_args.append("--" + a)
+        self.extra_args = [] if extra_args is None else [flag(a) for a in extra_args]
         if hal_target_backend == "rocm":
             self.extra_args += [
                 f"--iree-hip-target={self.target_chip}",
@@ -102,17 +102,16 @@ class CLIREEBackend(BackendBase):
             ]
     
     def compile(self, module_path: str, *, save_to : str = None, extra_options : CompilerOptions) -> str:
-        test_specific_args = extra_options.common_extra_args
+        test_specific_args = list(extra_options.common_extra_args)
         if self.hal_target_backend in extra_options.backend_specific_flags.keys():
-            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
+            test_specific_args += list(extra_options.backend_specific_flags[self.hal_target_backend])
         compile_args = self.extra_args + [flag(arg) for arg in test_specific_args]
         vmfb_path = os.path.join(save_to, "compiled_model.vmfb")
         arg_string = f"--iree-hal-target-backends={self.hal_target_backend} "
-        for arg in compile_args:
-            arg_string += f'{arg} '
+        arg_string += ' '.join(compile_args)
         detail_log = os.path.join(save_to, "detail", "compilation.detail.log")
         commands_log = os.path.join(save_to, "commands", "compilation.commands.log")
-        script = f"iree-compile {module_path} {arg_string}-o {vmfb_path} 1> {detail_log} 2>&1"
+        script = f"iree-compile {module_path} {arg_string} -o {vmfb_path} 1> {detail_log} 2>&1"
         with open(commands_log, "w") as file:
             file.write(script) 
         # remove old vmfb if it exists
@@ -126,9 +125,9 @@ class CLIREEBackend(BackendBase):
     
     def load(self, vmfb_path: str, *, func_name=None, extra_options : RuntimeOptions):
         """A bit hacky. func returns a script that would dump outputs to terminal output. Modified in config.run method"""
-        test_specific_args = extra_options.common_extra_args
+        test_specific_args = list(extra_options.common_extra_args)
         if self.hal_target_backend in extra_options.backend_specific_flags.keys():
-            test_specific_args += extra_options.backend_specific_flags[self.hal_target_backend]
+            test_specific_args += list(extra_options.backend_specific_flags[self.hal_target_backend])
         run_dir = Path(vmfb_path).parent
         def func(x: TestTensors) -> str:
             script = f"iree-run-module --module='{vmfb_path}' --device={self.device} "
@@ -148,11 +147,10 @@ class OnnxrtIreeEpBackend(BackendBase):
     def __init__(self, *, device="local-task", hal_target_device="llvm-cpu", extra_args : List[str] = None):
         self.device = device
         self.hal_target_device = hal_target_device
-        if extra_args:
-            self.extra_args = [flag(a) for a in extra_args]
-        elif hal_target_device == "hip":
+        self.extra_args = [] if extra_args is None else [flag(a) for a in extra_args]
+        if hal_target_device == "hip":
             # some extra args for Mi250 - some of these may not work for other chips
-            self.extra_args = [
+            self.extra_args += [
                 "--iree-hip-target=gfx90a",
             ]
         self.providers = ["IreeExecutionProvider"]

--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -33,8 +33,7 @@ from iree import runtime as ireert
 def flag(arg : str) -> str:
     if arg.startswith("--"):
         return arg
-    else:
-        return f'--{arg}'
+    return f'--{arg}'
 class SimpleIREEBackend(BackendBase):
     '''This backend uses iree to compile and run MLIR modules for a specified hal_target_backend'''
     def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", extra_args : List[str] = None):

--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -16,6 +16,14 @@ from e2e_testing.onnx_utils import *
 
 Module = TypeVar("Module")
 
+class ImporterOptions(NamedTuple):
+    opset_version : Optional[int] = None
+    large_model : bool = False
+    externalize_params : bool = False
+    externalize_inputs_threshold : Optional[int] = None
+    num_elements_threshold: int = 100
+    params_scope : str = "model"
+    param_gb_threshold : Optional[float] = None
 
 class OnnxModelInfo:
     """Stores information about an onnx test: the filepath to model.onnx, how to construct/download it, and how to construct sample inputs for a test run."""
@@ -32,6 +40,7 @@ class OnnxModelInfo:
         self.sess_options = ort.SessionOptions()
         self.dim_param_dict = None
         self.input_name_to_shape_map = None
+        self.importer_options = ImporterOptions(opset_version=opset_version)
 
     def forward(self, input: Optional[TestTensors] = None) -> TestTensors:
         """Applies self.model to self.input. Only override if necessary for specific models"""
@@ -60,6 +69,12 @@ class OnnxModelInfo:
     def update_dim_param_dict(self):
         """Can be overridden to modify a dictionary of dim parameters (self.dim_param_dict) used to 
         construct inputs for a model with dynamic dims.
+        """
+        pass
+
+    def update_importer_options(self):
+        """Override to specify:
+        self.importer_options = ImporterOptions(**kwargs)
         """
         pass
 

--- a/alt_e2eshark/e2e_testing/framework.py
+++ b/alt_e2eshark/e2e_testing/framework.py
@@ -8,7 +8,7 @@ import torch
 import abc
 import os
 from pathlib import Path
-from typing import Union, TypeVar, Tuple, NamedTuple, Dict, Optional, Callable
+from typing import Union, TypeVar, Tuple, NamedTuple, Dict, Optional, Callable, List
 from e2e_testing.storage import TestTensors
 from e2e_testing.onnx_utils import *
 
@@ -25,6 +25,23 @@ class ImporterOptions(NamedTuple):
     params_scope : str = "model"
     param_gb_threshold : Optional[float] = None
 
+class CompilerOptions(NamedTuple):
+    """Specify, for specific iree-hal-target-backends, a tuple of extra compiler flags. 
+       Also allows backend-agnostic options to be included."""
+    backend_specific_flags : Dict[str, Tuple[str]] = dict()
+    common_extra_args : Tuple[str] = tuple()
+
+class RuntimeOptions(NamedTuple):
+    """Specify, for specific iree-hal-target-backends, a tuple of extra runtime flags.
+       Also allows backend-agnostic options to be included."""
+    backend_specific_flags : Dict[str, Tuple[str]] = dict()
+    common_extra_args : Tuple[str] = tuple()
+
+class ExtraOptions(NamedTuple):
+    import_model_options : ImporterOptions = ImporterOptions()
+    compilation_options : CompilerOptions = CompilerOptions()
+    compiled_inference_options : RuntimeOptions = RuntimeOptions()
+
 class OnnxModelInfo:
     """Stores information about an onnx test: the filepath to model.onnx, how to construct/download it, and how to construct sample inputs for a test run."""
 
@@ -37,17 +54,21 @@ class OnnxModelInfo:
         self.name = name
         self.model = os.path.join(onnx_model_path, "model.onnx")
         self.opset_version = opset_version
-        self.sess_options = ort.SessionOptions()
+
         self.dim_param_dict = None
+        self.update_dim_param_dict()
         self.input_name_to_shape_map = None
-        self.importer_options = ImporterOptions(opset_version=opset_version)
+        self.update_input_name_to_shape_map()
+        self.sess_options = ort.SessionOptions()
+        self.update_sess_options()
+        self.extra_options = ExtraOptions()
+        self.update_extra_options()
 
     def forward(self, input: Optional[TestTensors] = None) -> TestTensors:
         """Applies self.model to self.input. Only override if necessary for specific models"""
         input = input.to_numpy().data
         if not os.path.exists(self.model):
             self.construct_model()
-        self.update_sess_options()
         session = ort.InferenceSession(self.model, self.sess_options)
         session_inputs = session.get_inputs()
         session_outputs = session.get_outputs()
@@ -59,6 +80,16 @@ class OnnxModelInfo:
 
         return TestTensors(model_output)
 
+    def update_dim_param_dict(self):
+        """Can be overridden to modify a dictionary of dim parameters (self.dim_param_dict) used to 
+        construct inputs for a model with dynamic dims.
+        """
+        pass
+
+    def update_input_name_to_shape_map(self):
+        """Can be overriden to construct an assocation map between the name of the input nodes and their shapes."""
+        pass
+
     def update_sess_options(self):
         """Can be overridden to modify session options (self.sess_options) for gold inference.
         It is sometimes useful to disable all optimizations, which can be done with:
@@ -66,20 +97,8 @@ class OnnxModelInfo:
         """
         pass
 
-    def update_dim_param_dict(self):
-        """Can be overridden to modify a dictionary of dim parameters (self.dim_param_dict) used to 
-        construct inputs for a model with dynamic dims.
-        """
-        pass
-
-    def update_importer_options(self):
-        """Override to specify:
-        self.importer_options = ImporterOptions(**kwargs)
-        """
-        pass
-
-    def contruct_input_name_to_shape_map(self):
-        """Can be overriden to construct an assocation map between the name of the input nodes and their shapes."""
+    def update_extra_options(self):
+        """Can be overridden to set self.extra_options = ExtraOptions(**kwargs)"""
         pass
 
     def construct_model(self):
@@ -166,7 +185,7 @@ CompiledOutput = Union[CompiledArtifact, ort.InferenceSession]
 class TestConfig(abc.ABC):
 
     @abc.abstractmethod
-    def import_model(self, program: TestModel, *, save_to: str) -> Tuple[ModelArtifact, str | None]:
+    def import_model(self, program: TestModel, *, save_to: str, extra_options : ImporterOptions) -> Tuple[ModelArtifact, str | None]:
         """imports the test model to model artifact (e.g., loads the onnx model )"""
         pass
 
@@ -176,16 +195,16 @@ class TestConfig(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def compile(self, module: ModelArtifact, *, save_to: str) -> CompiledOutput:
+    def compile(self, module: ModelArtifact, *, save_to: str, extra_options : CompilerOptions) -> CompiledOutput:
         """converts the test program to a compiled artifact"""
         pass
 
     @abc.abstractmethod
-    def run(self, artifact: CompiledOutput, input: TestTensors) -> TestTensors:
+    def run(self, artifact: CompiledOutput, input: TestTensors, extra_options : RuntimeOptions) -> TestTensors:
         """runs the input through the compiled artifact"""
         pass
 
-    def benchmark(self, artifact: CompiledOutput, input: TestTensors, repetitions: int, *, func_name=None) -> float:
+    def benchmark(self, artifact: CompiledOutput, input: TestTensors, repetitions: int, *, func_name=None, extra_options : RuntimeOptions) -> float:
         """returns a float representing inference time in ms"""
         pass
 

--- a/alt_e2eshark/e2e_testing/storage.py
+++ b/alt_e2eshark/e2e_testing/storage.py
@@ -171,20 +171,14 @@ class TestTensors:
         """returns a copy of self with a converted dtype (at a particular index, if specified)"""
         if self.type == numpy.ndarray:
             if index:
-                try:
-                    new_data = self.data
-                    new_data[index] = new_data[index].astype(dtype)
-                except Exception as e:
-                    print("to_dtype failed due to excepton {e}.")
+                new_data = self.data
+                new_data[index] = new_data[index].astype(dtype)
             else:
                 new_data = tuple([d.astype(dtype) for d in self.data])
         if self.type == torch.Tensor:
             if index:
-                try:
-                    new_data = self.data
-                    new_data[index] = new_data[index].to(dtype=dtype)
-                except Exception as e:
-                    print("to_dtype failed due to excepton {e}.")
+                new_data = self.data
+                new_data[index] = new_data[index].to(dtype=dtype)
             else:
                 new_data = tuple([d.to(dtype=dtype) for d in self.data])
         return TestTensors(new_data)

--- a/alt_e2eshark/iree_requirements.txt
+++ b/alt_e2eshark/iree_requirements.txt
@@ -3,3 +3,4 @@
 # install nightly build of iree-compiler and iree-runtime
 iree-base-compiler
 iree-base-runtime
+iree-turbine

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -107,7 +107,7 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
 
         shutil.copy(os.path.join(self.cache_dir, "model.onnx"), str(Path(self.model).parent))
 
-    def contruct_input_name_to_shape_map(self):
+    def update_input_name_to_shape_map(self):
         turnkey_dict = {}
         self.input_name_to_shape_map = {}
         with open(os.path.join(self.cache_dir, 'turnkey_stats.yaml'), 'rb') as stream:
@@ -125,7 +125,7 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
         if os.path.exists(input_path):
             return self.load_inputs(str(Path(self.model).parent))
 
-        self.contruct_input_name_to_shape_map()
+        self.update_input_name_to_shape_map()
         return get_sample_inputs_for_onnx_model(self.model, self.dim_param_dict, self.input_name_to_shape_map)
 
     def construct_model(self):

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -238,14 +238,13 @@ class AzureDownloadableModel(OnnxModelInfo):
 
 class SiblingModel(OnnxModelInfo):
     """convenience class for re-using an onnx model from another 'sibling' test"""
-
-    def __init__(self, og_model_info_class: type, og_name: str, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, og_model_info_class: type, og_name: str, name, onnx_model_path, opset_version = None):
         # additionally store an instance of the sibling test
-        run_dir = Path(self.model).parents[1]
+        run_dir = Path(onnx_model_path).parent
         og_model_path = os.path.join(run_dir, og_name)
         self.sibling_inst = og_model_info_class(og_name, og_model_path)
         self.opset_version = self.sibling_inst.opset_version
+        super().__init__(name, onnx_model_path, opset_version)
 
     def construct_model(self):
         if not os.path.exists(self.sibling_inst.model):

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -83,7 +83,8 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
         self.is_validated = is_validated
         self.model_url = model_url
         self.cache_dir = os.path.join(parent_cache_dir, name)
-
+        if not os.path.exists(self.cache_dir):
+            os.mkdir(self.cache_dir)
         super().__init__(name, onnx_model_path, opset_version)
 
     def unzip_model_archive(self, tar_path):
@@ -110,7 +111,10 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
     def update_input_name_to_shape_map(self):
         turnkey_dict = {}
         self.input_name_to_shape_map = {}
-        with open(os.path.join(self.cache_dir, 'turnkey_stats.yaml'), 'rb') as stream:
+        yaml_path = os.path.join(self.cache_dir, 'turnkey_stats.yaml')
+        if not os.path.isfile(yaml_path):
+            self.download_model_yaml(self.model_url)
+        with open(yaml_path, 'rb') as stream:
             turnkey_dict = yaml.safe_load(stream)
         if 'onnx_input_dimensions' in turnkey_dict.keys():
             for dim_param in turnkey_dict['onnx_input_dimensions']:

--- a/alt_e2eshark/onnx_tests/models/flux.py
+++ b/alt_e2eshark/onnx_tests/models/flux.py
@@ -1,105 +1,240 @@
 import os
 import torch
 from diffusers import FluxTransformer2DModel
-from e2e_testing.framework import OnnxModelInfo, ImporterOptions
+from e2e_testing.framework import (
+    OnnxModelInfo,
+    ExtraOptions,
+    ImporterOptions,
+    RuntimeOptions,
+    CompilerOptions,
+)
 from e2e_testing.registry import register_test
 from e2e_testing.storage import TestTensors
 from pathlib import Path
+from typing import Union
+
 
 class FluxTransformerModelInfo(OnnxModelInfo):
-    def __init__(self, name, onnx_model_path, opset_version = None):
-        super().__init__(name, onnx_model_path, opset_version)
+    def __init__(self, name, onnx_model_path, opset_version=None):
+        # set a cache dir for the hf model weights
+        parent_cache_dir = os.getenv("CACHE_DIR")
+        if not parent_cache_dir:
+            raise RuntimeError(
+                "Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files."
+            )
+        self.cache_dir = os.path.join(parent_cache_dir, name)
+        # hf model info
         self.hf_model_path = "black-forest-labs/FLUX.1-dev"
         self.model_dir = "transformer"
-        self.img_height=1024
-        self.img_width=1024
-        self.compression_factor=8
-        self.max_len=512
-        self.bs=1
-        self.torch_dtype=torch.float32
-        self.param_path = str(Path(self.model).parent / "model_params.irpa")
+        # where to save the irpa file for iree-run-module
+        # note, the importer will generate another param file at
+        # "onnx_model_path / model.torch_onnx_params.irpa", since
+        # some bias values are large enough to externalize, but weren't
+        # part of the saftensors files.
+        self.param_path = str(Path(onnx_model_path) / "model_params.irpa")
+        # these are customizable:
+        self.bs = 1
+        self.max_len = 512
+        self.img_height = 1024
+        self.img_width = 1024
+        self.compression_factor = 8
+        self.torch_dtype = torch.float32
+        # these are determined from above
+        self.latent_h = self.img_height // self.compression_factor
+        self.latent_w = self.img_width // self.compression_factor
+        self.latent_dim = (self.latent_h // 2) * (self.latent_w // 2)
+        super().__init__(name, onnx_model_path, opset_version)
 
     def update_dim_param_dict(self):
-        self.dim_param_dict = {"B" : 1, "latent_dim" : 128, "L" : 128}
+        self.dim_param_dict = {
+            "B": self.bs,
+            "latent_dim": self.latent_dim,
+            "L": self.max_len,
+        }
 
-    def update_importer_options(self):
-        self.importer_options = ImporterOptions(externalize_inputs_threshold=7, externalize_params=True, large_model=True)
-        self.runtime_options = f" --parameters=model={self.param_path} --parameters=model={Path(self.model).parent / 'model.torch_onnx_params.irpa'}"
+    def update_extra_options(self):
+        # we decided to set `export_params=False` and `do_constant_folding=False`
+        # in the torch.onnx.export of this model. This will convert initializers
+        # to inputs in the onnx model, which we need to convert back to util.global
+        # ops in the importer. Therefore, we specify that the model has 7 actual inputs
+        # for the `externalize_params` route in the iree-import-onnx tool. `large-model`
+        # is additionally specified since we don't need to update the opset version
+        # or check the model size.
+        # The compile flags for rocm match what we are using for similar models.
+        # Lastly, we add some runtime options specifically to point to the irpa files
+        # generated for this test.
+        rocm_compile_flags = (
+            "iree-execution-model=async-external",
+            "iree-global-opt-propagate-transposes=1",
+            "iree-opt-const-eval=0",
+            "iree-opt-outer-dim-concat=1",
+            "iree-opt-aggressively-propagate-transposes=1",
+            "iree-dispatch-creation-enable-aggressive-fusion",
+            "iree-codegen-llvmgpu-use-vector-distribution=1",
+            "iree-llvmgpu-enable-prefetch=1",
+            "iree-codegen-gpu-native-math-precision=1",
+            "iree-hip-legacy-sync=0",
+            "iree-opt-data-tiling=0",
+            "iree-vm-target-truncate-unsupported-floats",
+            "iree-hal-force-indirect-command-buffers",
+            "iree-preprocessing-pass-pipeline="
+            "'builtin.module(util.func(iree-global-opt-raise-special-ops, iree-flow-canonicalize), "
+            "iree-preprocessing-transpose-convolution-pipeline, "
+            "iree-preprocessing-pad-to-intrinsics, "
+            "util.func(iree-preprocessing-generalize-linalg-matmul-experimental))'",
+            "iree-dispatch-creation-enable-fuse-horizontal-contractions=1",
+        )
+        self.extra_options = ExtraOptions(
+            import_model_options=ImporterOptions(
+                externalize_inputs_threshold=7,
+                externalize_params=True,
+                large_model=True,
+            ),
+            compilation_options=CompilerOptions(
+                backend_specific_flags={
+                    "rocm": rocm_compile_flags,
+                    "hip": rocm_compile_flags,
+                }
+            ),
+            compiled_inference_options=RuntimeOptions(
+                common_extra_args=(
+                    f"parameters=model={self.param_path}",
+                    f'parameters=model={Path(self.model).parent / "model.torch_onnx_params.irpa"}',
+                )
+            ),
+        )
 
     def construct_inputs(self):
-        latent_h, latent_w = self.img_height // self.compression_factor, self.img_width // self.compression_factor
-        config = FluxTransformer2DModel.load_config(self.hf_model_path,
-                                                        subfolder=self.model_dir)
-        return TestTensors((torch.randn(self.bs, (latent_h // 2) * (latent_w // 2),
-                                        config["in_channels"],
-                                        dtype=self.torch_dtype),
-                            torch.randn(self.bs,
-                                        self.max_len,
-                                        config['joint_attention_dim'],
-                                        dtype=self.torch_dtype),
-                            torch.randn(self.bs,
-                                        config['pooled_projection_dim'],
-                                        dtype=self.torch_dtype),
-                            torch.tensor([1.]*self.bs, dtype=self.torch_dtype),
-                            torch.randn((latent_h // 2) * (latent_w // 2),
-                                        3,
-                                        dtype=self.torch_dtype),
-                            torch.randn(self.max_len, 3, dtype=self.torch_dtype),
-                            torch.tensor([1.]*self.bs, dtype=self.torch_dtype),))
+        torch.manual_seed(0)
+        shapes, dtypes = self.get_signature()
+        return TestTensors(
+            (
+                torch.randn(*(shapes[0]), dtype=dtypes[0]),
+                torch.randn(*(shapes[1]), dtype=dtypes[1]),
+                torch.randn(*(shapes[2]), dtype=dtypes[2]),
+                torch.ones(*(shapes[3]), dtype=dtypes[3]),
+                torch.randn(*(shapes[4]), dtype=dtypes[4]),
+                torch.randn(*(shapes[5]), dtype=dtypes[5]),
+                torch.ones(*(shapes[6]), dtype=dtypes[6]),
+            )
+        )
 
     def construct_model(self):
-        input_names = [
-            'hidden_states', 'encoder_hidden_states', 'pooled_projections',
-            'timestep', 'img_ids', 'txt_ids', 'guidance'
-        ]
-        if not os.path.isfile(self.model):
-            print("loading model")
-            model = FluxTransformer2DModel.from_pretrained(self.hf_model_path,
-                                                            subfolder=self.model_dir,
-                                                            torch_dtype=self.torch_dtype)
-            print("model loaded")
+        if os.path.isfile(self.model):
+            return
+
+        # we will use iree turbine to save params
+        try:
             from iree.turbine.aot import save_module_parameters
-            print("saving params")
-            save_module_parameters(self.param_path, model)
-            print("params saved")
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                "The package iree-turbine (try pip install iree-turbine) "
+                "is used to save hf model parameters to irpa format for flux."
+            ) from e
 
-            output_names = ["latent"]
-            dynamic_axes = {
-                'hidden_states': {0: 'B', 1: 'latent_dim'},
-                'encoder_hidden_states': {0: 'B',1: 'L'},
-                'pooled_projections': {0: 'B'},
-                'timestep': {0: 'B'},
-                'img_ids': {0: 'latent_dim'},
-                'txt_ids': {0: 'L'},
-                'guidance': {0: 'B'},
-            }
-            sample_inputs= self.construct_inputs().data
-            with torch.inference_mode():
-                print("exporting hf model to onnx")
-                torch.onnx.export(model,
-                                    sample_inputs,
-                                    self.model,
-                                    export_params=False,
-                                    do_constant_folding=False,
-                                    input_names=input_names,
-                                    output_names=output_names,
-                                    dynamic_axes=dynamic_axes)
-                print("onnx model generated")
+        print("\nloading hf model...")
+        model = FluxTransformer2DModel.from_pretrained(
+            self.hf_model_path,
+            subfolder=self.model_dir,
+            cache_dir=self.cache_dir,
+            torch_dtype=self.torch_dtype,
+        )
+        print("hf model loaded.")
+
+        print("saving params (this might take a while)...")
+        save_module_parameters(self.param_path, model)
+        print("params saved.")
+
+        input_names = [
+            "hidden_states",
+            "encoder_hidden_states",
+            "pooled_projections",
+            "timestep",
+            "img_ids",
+            "txt_ids",
+            "guidance",
+        ]
+        dynamic_axes = {
+            "hidden_states": {0: "B", 1: "latent_dim"},
+            "encoder_hidden_states": {0: "B", 1: "L"},
+            "pooled_projections": {0: "B"},
+            "timestep": {0: "B"},
+            "img_ids": {0: "latent_dim"},
+            "txt_ids": {0: "L"},
+            "guidance": {0: "B"},
+        }
+        output_names = ["latent"]
+        sample_inputs = self.construct_inputs().data
+        with torch.inference_mode():
+            print("exporting hf model to onnx (this might take a while)...")
+            torch.onnx.export(
+                model,
+                sample_inputs,
+                self.model,
+                export_params=False,
+                do_constant_folding=False,
+                input_names=input_names,
+                output_names=output_names,
+                dynamic_axes=dynamic_axes,
+            )
+            print("onnx model generated.")
 
         if not os.path.isfile(self.model):
-            raise RuntimeError(f"Torch onnx export failed to produce an onnx model at {self.model}")
-    
+            raise RuntimeError(
+                f"Torch onnx export failed to produce an onnx model at {self.model}"
+            )
+
     def forward(self, input):
         with torch.inference_mode():
-            model = FluxTransformer2DModel.from_pretrained(self.hf_model_path,
-                                                            subfolder=self.model_dir,
-                                                            torch_dtype=self.torch_dtype)
+            model = FluxTransformer2DModel.from_pretrained(
+                self.hf_model_path,
+                subfolder=self.model_dir,
+                cache_dir=self.cache_dir,
+                torch_dtype=self.torch_dtype,
+            )
             data = input.to_torch().data
-            return TestTensors(model.forward(data[0], data[1],data[2],data[3],data[4],data[5],data[6], return_dict=False))
+            return TestTensors(
+                model.forward(
+                    data[0],
+                    data[1],
+                    data[2],
+                    data[3],
+                    data[4],
+                    data[5],
+                    data[6],
+                    return_dict=False,
+                )
+            )
 
+    def get_signature(self, *, from_inputs=True, leave_dynamic=False):
+        config = FluxTransformer2DModel.load_config(
+            self.hf_model_path, subfolder=self.model_dir
+        )
+
+        def d(dim: Union[str, int]) -> Union[str, int]:
+            if leave_dynamic or isinstance(dim, int):
+                return dim
+            return self.dim_param_dict[dim]
+
+        B = d("B")
+        L = d("L")
+        latent_dim = d("latent_dim")
+
+        if from_inputs:
+            shapes = [
+                [B, latent_dim, config["in_channels"]],
+                [B, L, config["joint_attention_dim"]],
+                [B, config["pooled_projection_dim"]],
+                [B],
+                [latent_dim, 3],
+                [L, 3],
+                [B],
+            ]
+        else:
+            shapes = [[B, latent_dim, config["in_channels"]]]
+
+        dtypes = len(shapes) * [self.torch_dtype]
+        return shapes, dtypes
 
 
 register_test(FluxTransformerModelInfo, "flux_1_dev_transformer")
-
-
-

--- a/alt_e2eshark/onnx_tests/models/flux.py
+++ b/alt_e2eshark/onnx_tests/models/flux.py
@@ -1,0 +1,105 @@
+import os
+import torch
+from diffusers import FluxTransformer2DModel
+from e2e_testing.framework import OnnxModelInfo, ImporterOptions
+from e2e_testing.registry import register_test
+from e2e_testing.storage import TestTensors
+from pathlib import Path
+
+class FluxTransformerModelInfo(OnnxModelInfo):
+    def __init__(self, name, onnx_model_path, opset_version = None):
+        super().__init__(name, onnx_model_path, opset_version)
+        self.hf_model_path = "black-forest-labs/FLUX.1-dev"
+        self.model_dir = "transformer"
+        self.img_height=1024
+        self.img_width=1024
+        self.compression_factor=8
+        self.max_len=512
+        self.bs=1
+        self.torch_dtype=torch.float32
+        self.param_path = str(Path(self.model).parent / "model_params.irpa")
+
+    def update_dim_param_dict(self):
+        self.dim_param_dict = {"B" : 1, "latent_dim" : 128, "L" : 128}
+
+    def update_importer_options(self):
+        self.importer_options = ImporterOptions(externalize_inputs_threshold=7, externalize_params=True, large_model=True)
+        self.runtime_options = f" --parameters=model={self.param_path} --parameters=model={Path(self.model).parent / 'model.torch_onnx_params.irpa'}"
+
+    def construct_inputs(self):
+        latent_h, latent_w = self.img_height // self.compression_factor, self.img_width // self.compression_factor
+        config = FluxTransformer2DModel.load_config(self.hf_model_path,
+                                                        subfolder=self.model_dir)
+        return TestTensors((torch.randn(self.bs, (latent_h // 2) * (latent_w // 2),
+                                        config["in_channels"],
+                                        dtype=self.torch_dtype),
+                            torch.randn(self.bs,
+                                        self.max_len,
+                                        config['joint_attention_dim'],
+                                        dtype=self.torch_dtype),
+                            torch.randn(self.bs,
+                                        config['pooled_projection_dim'],
+                                        dtype=self.torch_dtype),
+                            torch.tensor([1.]*self.bs, dtype=self.torch_dtype),
+                            torch.randn((latent_h // 2) * (latent_w // 2),
+                                        3,
+                                        dtype=self.torch_dtype),
+                            torch.randn(self.max_len, 3, dtype=self.torch_dtype),
+                            torch.tensor([1.]*self.bs, dtype=self.torch_dtype),))
+
+    def construct_model(self):
+        input_names = [
+            'hidden_states', 'encoder_hidden_states', 'pooled_projections',
+            'timestep', 'img_ids', 'txt_ids', 'guidance'
+        ]
+        if not os.path.isfile(self.model):
+            print("loading model")
+            model = FluxTransformer2DModel.from_pretrained(self.hf_model_path,
+                                                            subfolder=self.model_dir,
+                                                            torch_dtype=self.torch_dtype)
+            print("model loaded")
+            from iree.turbine.aot import save_module_parameters
+            print("saving params")
+            save_module_parameters(self.param_path, model)
+            print("params saved")
+
+            output_names = ["latent"]
+            dynamic_axes = {
+                'hidden_states': {0: 'B', 1: 'latent_dim'},
+                'encoder_hidden_states': {0: 'B',1: 'L'},
+                'pooled_projections': {0: 'B'},
+                'timestep': {0: 'B'},
+                'img_ids': {0: 'latent_dim'},
+                'txt_ids': {0: 'L'},
+                'guidance': {0: 'B'},
+            }
+            sample_inputs= self.construct_inputs().data
+            with torch.inference_mode():
+                print("exporting hf model to onnx")
+                torch.onnx.export(model,
+                                    sample_inputs,
+                                    self.model,
+                                    export_params=False,
+                                    do_constant_folding=False,
+                                    input_names=input_names,
+                                    output_names=output_names,
+                                    dynamic_axes=dynamic_axes)
+                print("onnx model generated")
+
+        if not os.path.isfile(self.model):
+            raise RuntimeError(f"Torch onnx export failed to produce an onnx model at {self.model}")
+    
+    def forward(self, input):
+        with torch.inference_mode():
+            model = FluxTransformer2DModel.from_pretrained(self.hf_model_path,
+                                                            subfolder=self.model_dir,
+                                                            torch_dtype=self.torch_dtype)
+            data = input.to_torch().data
+            return TestTensors(model.forward(data[0], data[1],data[2],data[3],data[4],data[5],data[6], return_dict=False))
+
+
+
+register_test(FluxTransformerModelInfo, "flux_1_dev_transformer")
+
+
+

--- a/alt_e2eshark/onnx_tests/models/model.py
+++ b/alt_e2eshark/onnx_tests/models/model.py
@@ -12,3 +12,4 @@ from .vision_models import *
 from .deeplab import *
 from .migraphx import *
 from .nlp import *
+from .flux import *

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -244,7 +244,12 @@ def run_tests(
             curr_stage = "compiled_inference"
             if curr_stage in stages:
                 notify_stage()
-                outputs_raw = config.run(compiled_artifact, inputs, func_name=func_name)
+                options = None
+                try:
+                    options = inst.runtime_options
+                except AttributeError:
+                    pass 
+                outputs_raw = config.run(compiled_artifact, inputs, func_name=func_name, extra_options=options)
                 outputs_raw.save_to(log_dir + "output")
 
             # apply model-specific post-processing:


### PR DESCRIPTION
The most significant infrastructure change is with some reworks to OnnxModelInfo:

1. `OnnxModelInfo` now has an attribute for `ExtraOptions`, which holds test-specific options for later testing stages beyond setup. This was required to allow running with external params, passing compile flags, and setting custom mlir import options.
2. All attributes configurable via `update_*` methods in `OnnxModelInfo` are updated in the init method immediately. This required reworking a few helper classes which relied on calling these at a specific time. 

Another infrastructure change is through the migration to using `iree-import-onnx` rather than torch-mlir's onnx importer. This is to allow externalizing parameters. 

Adds the following three tests:

- `flux_1_dev_transformer`
- `flux_1_dev_clip`
- `flux_1_dev_t5`



