### PR TITLE
Add `tf-keras` to required packages

### DIFF
--- a/alt_e2eshark/base_requirements.txt
+++ b/alt_e2eshark/base_requirements.txt
@@ -16,4 +16,5 @@ azure-storage-blob
 compressed_tensors
 fugashi
 tensorflow
+tf-keras
 timm


### PR DESCRIPTION
Adds the package `tf-keras` to `base_requirements.txt` for backwards compatibility in HuggingFace models that require `tensorflow` during export. 