### PR TITLE
Cleanup issues with a few helper classes

### DIFF
--- a/alt_e2eshark/e2e_testing/storage.py
+++ b/alt_e2eshark/e2e_testing/storage.py
@@ -183,14 +183,15 @@ class TestTensors:
                 new_data = tuple([d.to(dtype=dtype) for d in self.data])
         return TestTensors(new_data)
 
-    def save_to(self, path: str):
-        """path should be of the form /path/to/log/folder/unformattedname"""
+    def save_to(self, path: str, *, base_stem: str = "input"):
+        """path should be to test-run/<test-name>/ (default) or run-directory/<test-name>/ if modified"""
         if self.type == torch.Tensor:
             data = self.data
         else:
             data = self.to_torch().data
         for i in range(len(data)):
-            write_inference_input_bin_file(data[i], path + f".{i}.bin")
+            file_path = Path(path) / f"{base_stem}.{i}.bin"
+            write_inference_input_bin_file(data[i], str(file_path))
 
     @staticmethod
     def load_from(shapes, torch_dtypes, dir_path: str, name: str = "input"):

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -37,19 +37,15 @@ class HfDownloadableModel(OnnxModelInfo):
     """This class should be used to download models from Huggingface model hub."""
 
     def __init__(self, full_model_path, task_name, name, onnx_model_path):
-        # Checking if CACHE_DIR is set here will allow us to redefine
-        # HF_HOME and HUGGINGFACE_HUB_CACHE without requiring them to
-        # be set at shell level.
         parent_cache_dir = os.getenv("CACHE_DIR")
         if not parent_cache_dir:
             raise RuntimeError(
                 "Please specify a cache directory path in the CACHE_DIR environment variable "
                 "for storing large model files."
             )
-        os.environ["HF_HOME"] = "" if parent_cache_dir is None else parent_cache_dir
-        os.environ["HUGGINGFACE_HUB_CACHE"] = (
-            "" if parent_cache_dir is None else parent_cache_dir
-        )
+        # set HF cache explicitly to match provided CACHE_DIR
+        os.environ["HF_HOME"] = parent_cache_dir
+        os.environ["HUGGINGFACE_HUB_CACHE"] = parent_cache_dir
         # These tests require optimum. Importing here to avoid raising an exception on importing this file.
         try:
             from optimum.exporters.onnx import main_export

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -8,33 +8,38 @@ import requests
 import tarfile
 import shutil
 import yaml
+import os
+
+from typing import List, Optional
+
 import onnx
 import onnxruntime
 
 from onnx.helper import make_node, make_graph, make_model
 from pathlib import Path
 from e2e_testing import azutils
-from e2e_testing.framework import ExtraOptions, ImporterOptions, OnnxModelInfo, TestTensors
+from e2e_testing.framework import (
+    ExtraOptions,
+    ImporterOptions,
+    OnnxModelInfo,
+    TestTensors,
+)
 from e2e_testing.onnx_utils import (
     modify_model_output,
     find_node,
-    get_sample_inputs_for_onnx_model
+    get_sample_inputs_for_onnx_model,
 )
 
 # Checking if CACHE_DIR is set here will allow us to redefine
 # HF_HOME and HUGGINGFACE_HUB_CACHE without requiring them to
 # be set at shell level.
-import os
 parent_cache_dir = os.getenv("CACHE_DIR")
 
-os.environ['HF_HOME'] = "" if parent_cache_dir is None else parent_cache_dir
-os.environ['HUGGINGFACE_HUB_CACHE'] = "" if parent_cache_dir is None else parent_cache_dir
+os.environ["HF_HOME"] = "" if parent_cache_dir is None else parent_cache_dir
+os.environ["HUGGINGFACE_HUB_CACHE"] = (
+    "" if parent_cache_dir is None else parent_cache_dir
+)
 
-
-try:
-    import optimum.exporters.onnx as exporter
-except ImportError:
-    print("Failed to import ONNX Exporter module from optimum. Please install through `pip install optimum[exporters]`.")
 
 """This file contains several helpful child classes of OnnxModelInfo."""
 
@@ -43,13 +48,24 @@ class HfDownloadableModel(OnnxModelInfo):
     """This class should be used to download models from Huggingface model hub."""
 
     def __init__(self, full_model_path, task_name, name, onnx_model_path):
+
+        # These tests require optimum. Importing here to avoid raising an exception on importing this file.
+        try:
+            from optimum.exporters.onnx import main_export
+        except ImportError:
+            print(
+                "Failed to import ONNX Exporter module from optimum. "
+                "Please install through `pip install optimum[exporters]`."
+            )
+        self.export = main_export
         opset_version = 21
         self.model_repo_path = full_model_path.replace("hf_", "")
         self.task = task_name
         parent_cache_dir = os.getenv("CACHE_DIR")
         if not parent_cache_dir:
             raise RuntimeError(
-                "Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files."
+                "Please specify a cache directory path in the CACHE_DIR environment variable "
+                "for storing large model files."
             )
         # Appending the test name just adds one redundant level of nesting to the cache dir.
         # Use the value of the CACHE_DIR directly, the segregation of distinct models should
@@ -57,9 +73,16 @@ class HfDownloadableModel(OnnxModelInfo):
         self.cache_dir = parent_cache_dir
         super().__init__(name, onnx_model_path, opset_version)
 
+    def update_extra_options(self):
+        # called in __init__
+        # default to using opset version 21 for all ONNX Model Zoo models.
+        self.extra_options = ExtraOptions(
+            import_model_options=ImporterOptions(opset_version=21)
+        )
+
     def export_model(self):
         model_dir = str(Path(self.model).parent)
-        exporter.main_export(
+        self.export(
             self.model_repo_path,
             output=model_dir,
             task=self.task,
@@ -89,17 +112,21 @@ class HfDownloadableModel(OnnxModelInfo):
             self.model = found_models[0]
             return
         if len(found_models) > 1:
-            print(f'Found multiple model.onnx files: {found_models}')
-            print(f'Picking the first model found to use: {found_models[0]}')
+            print(f"Found multiple model.onnx files: {found_models}")
+            print(f"Picking the first model found to use: {found_models[0]}")
             self.model = found_models[0]
             return
-        raise OSError(f"No onnx model could be found, downloaded, or extracted to {model_dir}")
+        raise OSError(
+            f"No onnx model could be found, downloaded, or extracted to {model_dir}"
+        )
 
 
 class OnnxModelZooDownloadableModel(OnnxModelInfo):
     """This class should be used to download models from ONNX Model Zoo (onnx/models)."""
 
-    def __init__(self, is_validated: bool, model_url: str, name: str, onnx_model_path: str):
+    def __init__(
+        self, is_validated: bool, model_url: str, name: str, onnx_model_path: str
+    ):
         opset_version = 21
         parent_cache_dir = os.getenv("CACHE_DIR")
         if not parent_cache_dir:
@@ -109,58 +136,76 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
         self.is_validated = is_validated
         self.model_url = model_url
         self.cache_dir = os.path.join(parent_cache_dir, name)
-        if not os.path.exists(self.cache_dir):
-            os.mkdir(self.cache_dir)
+        os.makedirs(self.cache_dir, exist_ok=True)
+        self.yaml_path = self.get_model_yaml()
+        # super().__init__ will also call all update methods
         super().__init__(name, onnx_model_path, opset_version)
 
-    def update_extra_options(self):
-        # Default to using opset version 21 for all ONNX Model Zoo models.
-        self.extra_options = ExtraOptions(import_model_options=ImporterOptions(opset_version=21))
+    def get_model_yaml(self) -> Optional[str]:
+        """Tries to download turnkey_stats.yaml to self.cache_dir.
+        Returns a path to the dowloaded file if sucessful."""
+        # called in __init__
+        yaml_path = os.path.join(self.cache_dir, "turnkey_stats.yaml")
+        if not os.path.exists(yaml_path):
+            turnkey_yaml_url = (
+                "/".join(self.model_url.split("/")[:-1]) + "/turnkey_stats.yaml"
+            )
+            content = requests.get(turnkey_yaml_url).content
+            # don't save an empty yaml file
+            if content is None or len(content) == 0:
+                return
+            with open(yaml_path, "wb") as out_file:
+                out_file.write(content)
+        return yaml_path
 
-    def unzip_model_archive(self, tar_path):
+    def update_extra_options(self):
+        # called in __init__
+        # default to using opset version 21 for all ONNX Model Zoo models.
+        self.extra_options = ExtraOptions(
+            import_model_options=ImporterOptions(opset_version=21)
+        )
+
+    def update_input_name_to_shape_map(self):
+        # called in __init__
+        # reads the input name to shape map from downloaded yaml file
+        if not self.yaml_path:
+            return
+        turnkey_dict = dict()
+        self.input_name_to_shape_map = dict()
+        if self.yaml_path:
+            with open(self.yaml_path, "rb") as stream:
+                turnkey_dict = yaml.safe_load(stream)
+        if "onnx_input_dimensions" in turnkey_dict.keys():
+            for dim_param in turnkey_dict["onnx_input_dimensions"]:
+                self.input_name_to_shape_map[dim_param] = turnkey_dict[
+                    "onnx_input_dimensions"
+                ][dim_param]
+
+    def unzip_model_archive(self, tar_path: str):
+        """helper function for unzipping model and provided inputs to the test-dir"""
         model_dir = str(Path(self.model).parent)
         with tarfile.open(tar_path) as tar:
             for subdir_and_file in tar.getmembers():
                 if "test_data_set_0/input" in subdir_and_file.name:
-                    subdir_and_file.name = subdir_and_file.name.split('/')[-1]
+                    subdir_and_file.name = subdir_and_file.name.split("/")[-1]
                     tar.extract(subdir_and_file, path=model_dir)
                 if ".onnx" in subdir_and_file.name:
                     subdir_and_file.name = "model.onnx"
                     tar.extract(subdir_and_file, path=model_dir)
 
-    def download_model_yaml(self, model_url: str):
-        # The cache dir should already have model.onnx
-        if not os.path.exists(os.path.join(self.cache_dir, "turnkey_stats.yaml")):
-            turnkey_yaml_url = '/'.join(model_url.split('/')[:-1]) + '/turnkey_stats.yaml'
-            content = requests.get(turnkey_yaml_url).content
-            with open(os.path.join(self.cache_dir, "turnkey_stats.yaml"), "wb") as out_file:
-                out_file.write(content)
-
-        shutil.copy(os.path.join(self.cache_dir, "model.onnx"), str(Path(self.model).parent))
-
-    def update_input_name_to_shape_map(self):
-        turnkey_dict = {}
-        self.input_name_to_shape_map = {}
-        yaml_path = os.path.join(self.cache_dir, 'turnkey_stats.yaml')
-        if not os.path.isfile(yaml_path):
-            self.download_model_yaml(self.model_url)
-        with open(yaml_path, 'rb') as stream:
-            turnkey_dict = yaml.safe_load(stream)
-        if 'onnx_input_dimensions' in turnkey_dict.keys():
-            for dim_param in turnkey_dict['onnx_input_dimensions']:
-                self.input_name_to_shape_map[dim_param] = turnkey_dict['onnx_input_dimensions'][dim_param]
-
     def construct_inputs(self) -> TestTensors:
         if not os.path.exists(self.model):
             self.construct_model()
-        self.update_dim_param_dict()
 
-        input_path = os.path.join(str(Path(self.model).parent), 'input_0.pb')
+        input_path = os.path.join(str(Path(self.model).parent), "input_0.pb")
+        # if the download included input_*.pb files, load them:
         if os.path.exists(input_path):
             return self.load_inputs(str(Path(self.model).parent))
 
-        self.update_input_name_to_shape_map()
-        return get_sample_inputs_for_onnx_model(self.model, self.dim_param_dict, self.input_name_to_shape_map)
+        # otherwise do default input generation
+        return get_sample_inputs_for_onnx_model(
+            self.model, self.dim_param_dict, self.input_name_to_shape_map
+        )
 
     def construct_model(self):
         # Look in the test-run dir for the model file.
@@ -168,57 +213,50 @@ class OnnxModelZooDownloadableModel(OnnxModelInfo):
         # final_model_path should look like this: <directory>/<test/model_name>/<test/model_name>.onnx
         model_dir = str(Path(self.model).parent)
 
-        # if cache directory doesn't exist, then make it
-        if not os.path.exists(self.cache_dir):
-            os.mkdir(self.cache_dir)
+        # search for a .onnx file in the ./test-run/testname/ dir
+        found_models = []
+        for root, _, files in os.walk(model_dir):
+            for name in files:
+                if name.endswith(".onnx"):
+                    found_models.append(os.path.abspath(os.path.join(root, name)))
 
-        def find_models(model_dir):
-            # search for a .onnx file in the ./test-run/testname/ dir
-            found_models = []
-            found_model_in_cache = False
-            for root, dirs, files in os.walk(model_dir):
-                for name in files:
-                    if name[-5:] == ".onnx":
-                        found_models.append(os.path.abspath(os.path.join(root, name)))
-            if len(found_models) == 0:
-                for _, _, files in os.walk(self.cache_dir):
-                    for name in files:
-                        if name[-6:] == "tar.gz" or name[-5:] == "model.onnx":
-                            found_model_in_cache = True
-                            break
-            return found_models, found_model_in_cache
+        # one model in test-dir: return
+        if len(found_models) == 1:
+            self.model = found_models[0]
+            return
 
-        dest_file = os.path.join(self.cache_dir, self.model_url.split('/')[-1] if self.is_validated else "model.onnx")
-        find_models_in_test_dir, found_model_in_cache = find_models(model_dir)
+        # multiple models in test-dir: pick one
+        if len(found_models) > 1:
+            print(f"Found multiple model.onnx files: {found_models}")
+            print(f"Picking the first model found to use: {found_models[0]}")
+            self.model = found_models[0]
+            return
 
-        if len(find_models_in_test_dir) == 0 and not found_model_in_cache:
+        cache_file = os.path.join(
+            self.cache_dir,
+            self.model_url.split("/")[-1] if self.is_validated else "model.onnx",
+        )
+
+        # no model and cache doesn't exist: download files to cache
+        if not os.path.exists(cache_file):
             print(f"Begin download for {self.name}")
             content = requests.get(self.model_url, stream=True).content
-
-            with open(dest_file, "wb") as model_out_file:
-                assert (
-                    content is not None and len(content) > 0
-                ), f"Failed to download model {self.name}"
+            if content is None or len(content) == 0:
+                raise ValueError(
+                    f"Contents downloaded from {self.model_url} are invalid. This is likely an invalid URL."
+                )
+            with open(cache_file, "wb") as model_out_file:
                 model_out_file.write(content)
-            if self.is_validated:
-                self.unzip_model_archive(dest_file)
-            else:
-                self.download_model_yaml(self.model_url)
-            find_models_in_test_dir, _ = find_models(model_dir)
-        if found_model_in_cache:
-            self.unzip_model_archive(dest_file) if self.is_validated else self.download_model_yaml(self.model_url)
-            find_models_in_test_dir, _ = find_models(model_dir)
-        if len(find_models_in_test_dir) == 1:
-            self.model = find_models_in_test_dir[0]
-            return
-        if len(find_models_in_test_dir) > 1:
-            print(f"Found multiple model.onnx files: {find_models_in_test_dir}")
-            print(f"Picking the first model found to use: {find_models_in_test_dir[0]}")
-            self.model = find_models_in_test_dir[0]
-            return
-        raise OSError(
-            f"No onnx model could be found, downloaded, or extracted to {model_dir}"
-        )
+
+        if self.is_validated:
+            self.unzip_model_archive(cache_file)
+        else:
+            os.symlink(cache_file, self.model)
+
+        if not os.path.exists(self.model):
+            raise OSError(
+                f"No onnx model could be found, downloaded, or extracted to {model_dir}"
+            )
 
 
 class AzureDownloadableModel(OnnxModelInfo):
@@ -227,18 +265,24 @@ class AzureDownloadableModel(OnnxModelInfo):
     def __init__(self, name: str, onnx_model_path: str):
         # TODO: Extract opset version from onnx.version.opset
         opset_version = 21
-        parent_cache_dir = os.getenv('CACHE_DIR')
+        parent_cache_dir = os.getenv("CACHE_DIR")
         if not parent_cache_dir:
-            raise RuntimeError("Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files.")
+            raise RuntimeError(
+                "Please specify a cache directory path in the CACHE_DIR environment variable for storing large model files."
+            )
         self.cache_dir = os.path.join(parent_cache_dir, name)
         super().__init__(name, onnx_model_path, opset_version)
 
     def update_extra_options(self):
         # Default to using opset version 21 for all Azure models.
-        self.extra_options = ExtraOptions(import_model_options=ImporterOptions(opset_version=21))
+        self.extra_options = ExtraOptions(
+            import_model_options=ImporterOptions(opset_version=21)
+        )
 
     def update_sess_options(self):
-        self.sess_options.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        self.sess_options.graph_optimization_level = (
+            onnxruntime.GraphOptimizationLevel.ORT_DISABLE_ALL
+        )
 
     def construct_model(self):
         # try to find a .onnx file in the test-run dir
@@ -268,15 +312,26 @@ class AzureDownloadableModel(OnnxModelInfo):
             self.model = found_models[0]
             return
         if len(found_models) > 1:
-            print(f'Found multiple model.onnx files: {found_models}')
-            print(f'Picking the first model found to use: {found_models[0]}')
+            print(f"Found multiple model.onnx files: {found_models}")
+            print(f"Picking the first model found to use: {found_models[0]}")
             self.model = found_models[0]
             return
-        raise OSError(f"No onnx model could be found, downloaded, or extracted to {model_dir}")
+        raise OSError(
+            f"No onnx model could be found, downloaded, or extracted to {model_dir}"
+        )
+
 
 class SiblingModel(OnnxModelInfo):
     """convenience class for re-using an onnx model from another 'sibling' test"""
-    def __init__(self, og_model_info_class: type, og_name: str, name, onnx_model_path, opset_version = None):
+
+    def __init__(
+        self,
+        og_model_info_class: type,
+        og_name: str,
+        name,
+        onnx_model_path,
+        opset_version=None,
+    ):
         # additionally store an instance of the sibling test
         run_dir = Path(onnx_model_path).parent
         og_model_path = os.path.join(run_dir, og_name)
@@ -292,6 +347,7 @@ class SiblingModel(OnnxModelInfo):
     def update_dim_param_dict(self):
         self.sibling_inst.update_dim_param_dict()
         self.dim_param_dict = self.sibling_inst.dim_param_dict
+
 
 def get_sibling_constructor(sibling_class, og_constructor, og_name):
     """Returns a constructor for the sibling class. Useful for convenient registration.
@@ -345,6 +401,7 @@ class TruncatedModel(SiblingModel):
         new_model = modify_model_output(inf_model, output_node)
         onnx.save(new_model, self.model)
         from e2e_testing.onnx_utils import get_op_frequency
+
         print(get_op_frequency(self.model))
 
 
@@ -437,6 +494,8 @@ class BuildAModel(OnnxModelInfo):
         self.construct_nodes()
         self.construct_i_o_value_info()
         self.construct_initializers()
-        graph = make_graph(self.node_list, "main", self.input_vi, self.output_vi, self.initializers)
+        graph = make_graph(
+            self.node_list, "main", self.input_vi, self.output_vi, self.initializers
+        )
         model = make_model(graph)
         onnx.save(model, self.model)

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -41,6 +41,11 @@ class HfDownloadableModel(OnnxModelInfo):
         # HF_HOME and HUGGINGFACE_HUB_CACHE without requiring them to
         # be set at shell level.
         parent_cache_dir = os.getenv("CACHE_DIR")
+        if not parent_cache_dir:
+            raise RuntimeError(
+                "Please specify a cache directory path in the CACHE_DIR environment variable "
+                "for storing large model files."
+            )
         os.environ["HF_HOME"] = "" if parent_cache_dir is None else parent_cache_dir
         os.environ["HUGGINGFACE_HUB_CACHE"] = (
             "" if parent_cache_dir is None else parent_cache_dir
@@ -57,12 +62,6 @@ class HfDownloadableModel(OnnxModelInfo):
         opset_version = 21
         self.model_repo_path = full_model_path.replace("hf_", "")
         self.task = task_name
-        parent_cache_dir = os.getenv("CACHE_DIR")
-        if not parent_cache_dir:
-            raise RuntimeError(
-                "Please specify a cache directory path in the CACHE_DIR environment variable "
-                "for storing large model files."
-            )
         # Appending the test name just adds one redundant level of nesting to the cache dir.
         # Use the value of the CACHE_DIR directly, the segregation of distinct models should
         # be handled by Huggingface itself.

--- a/alt_e2eshark/onnx_tests/helper_classes.py
+++ b/alt_e2eshark/onnx_tests/helper_classes.py
@@ -30,17 +30,6 @@ from e2e_testing.onnx_utils import (
     get_sample_inputs_for_onnx_model,
 )
 
-# Checking if CACHE_DIR is set here will allow us to redefine
-# HF_HOME and HUGGINGFACE_HUB_CACHE without requiring them to
-# be set at shell level.
-parent_cache_dir = os.getenv("CACHE_DIR")
-
-os.environ["HF_HOME"] = "" if parent_cache_dir is None else parent_cache_dir
-os.environ["HUGGINGFACE_HUB_CACHE"] = (
-    "" if parent_cache_dir is None else parent_cache_dir
-)
-
-
 """This file contains several helpful child classes of OnnxModelInfo."""
 
 
@@ -48,7 +37,14 @@ class HfDownloadableModel(OnnxModelInfo):
     """This class should be used to download models from Huggingface model hub."""
 
     def __init__(self, full_model_path, task_name, name, onnx_model_path):
-
+        # Checking if CACHE_DIR is set here will allow us to redefine
+        # HF_HOME and HUGGINGFACE_HUB_CACHE without requiring them to
+        # be set at shell level.
+        parent_cache_dir = os.getenv("CACHE_DIR")
+        os.environ["HF_HOME"] = "" if parent_cache_dir is None else parent_cache_dir
+        os.environ["HUGGINGFACE_HUB_CACHE"] = (
+            "" if parent_cache_dir is None else parent_cache_dir
+        )
         # These tests require optimum. Importing here to avoid raising an exception on importing this file.
         try:
             from optimum.exporters.onnx import main_export

--- a/alt_e2eshark/onnx_tests/models/hf_models.py
+++ b/alt_e2eshark/onnx_tests/models/hf_models.py
@@ -154,7 +154,6 @@ meta_constructor_multiple_choice = lambda m_name: (
 
 class HfModelWithTokenizers(HfDownloadableModel):
     def construct_inputs(self):
-        model_dir = str(Path(self.model).parent)
         prompt = ["Deeds will not be less valiant because they are unpraised."]
 
         tokenizer = get_tokenizer_from_model_path(self.model_repo_path, self.cache_dir)
@@ -167,12 +166,10 @@ class HfModelWithTokenizers(HfDownloadableModel):
         self.input_name_to_shape_map = {k: v.shape for (k, v) in tokens.items()}
 
         test_tensors = TestTensors(inputs)
-        test_tensors.save_to(model_dir)
         return test_tensors
 
 class HfModelMultipleChoice(HfDownloadableModel):
     def construct_inputs(self):
-        model_dir = str(Path(self.model).parent)
         tokenizer = get_tokenizer_from_model_path(self.model_repo_path, self.cache_dir)
 
         prompt = "France has a bread law, Le Décret Pain, with strict rules on what is allowed in a traditional baguette."
@@ -193,7 +190,6 @@ class HfModelMultipleChoice(HfDownloadableModel):
         self.input_name_to_shape_map = {k: v.shape for (k, v) in tokens.items()}
 
         test_tensors = TestTensors(inputs)
-        test_tensors.save_to(model_dir)
         return test_tensors
 
 
@@ -216,7 +212,6 @@ class HfModelWithImageSetup(HfDownloadableModel):
             img_ycbcr.unsqueeze_(0)
             return img_ycbcr
 
-        model_dir = str(Path(self.model).parent)
         inputs = setup_test_image()
 
         # TODO: Figure out a way to remove the hardcoded
@@ -225,7 +220,6 @@ class HfModelWithImageSetup(HfDownloadableModel):
         self.input_name_to_shape_map = {'pixel_values': inputs.shape}
 
         test_tensors = TestTensors((inputs,))
-        test_tensors.save_to(model_dir)
         return test_tensors
 
 

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -228,7 +228,7 @@ def run_tests(
                     inputs = inst.load_inputs(log_dir)
                 else:
                     inputs = inst.construct_inputs()
-                    inputs.save_to(log_dir + "input")
+                    inputs.save_to(log_dir)
 
             # run native inference
             curr_stage = "native_inference"
@@ -239,14 +239,14 @@ def run_tests(
                 # these shapes are needed to load the outputs from iree-run-module
                 if isinstance(config, CLOnnxTestConfig):
                     config.tensor_info_dict[t.unique_name] = ([list(d.shape) for d in golden_outputs_raw.data], [d.dtype for d in golden_outputs_raw.to_torch().data])
-                golden_outputs_raw.save_to(log_dir + "golden_output")
+                golden_outputs_raw.save_to(log_dir, base_stem="golden_output")
 
             # run inference with the compiled module
             curr_stage = "compiled_inference"
             if curr_stage in stages:
                 notify_stage()
                 outputs_raw = config.run(compiled_artifact, inputs, func_name=func_name, extra_options=options.compiled_inference_options)
-                outputs_raw.save_to(log_dir + "output")
+                outputs_raw.save_to(log_dir, base_stem="output")
 
             # apply model-specific post-processing:
             curr_stage = "postprocessing"


### PR DESCRIPTION
This patch

1. fixes setup for zoo models to align with `update_*` methods getting called in `__init__`
2. updates opset version for hf models on import by default
3. moves an import of optimum into the HF model info class `__init__` method
4. applies black formatting