### PR TITLE
Allows duplicate finder tool to search within multiple run directories

### DIFF
--- a/alt_e2eshark/utils/find_duplicate_models.py
+++ b/alt_e2eshark/utils/find_duplicate_models.py
@@ -53,10 +53,9 @@ def get_groupings(metadata_dicts: Dict[str, Dict]) -> Dict:
 def main(args):
     run_dir = ROOT / args.rundirectory
     metadata_dicts = dict()
-    for x in run_dir.glob("*/*.json"):
-        if x.name == "metadata.json":
-            test_name = x.parent.name
-            metadata_dicts[test_name] = load_json_dict(x)
+    for x in run_dir.glob("**/metadata.json"):
+        test_name = x.parent.name
+        metadata_dicts[test_name] = load_json_dict(x)
 
     groupings = get_groupings(metadata_dicts)
     found_redundancies = []


### PR DESCRIPTION
If running 

```
python run.py -t <some_test_1> -v -r test-run1 --get-metadata
```
and 

```
python run.py -t <some_test_2> -v -r test-run2 --get-metadata
```
Then 

```
python utils/find_duplicate_models.py -r . 
```
from the `alt_e2eshark` directory will identify duplicates from both `./test-run1/` and `./test-run2/`.