### PR TITLE
Fixes compiled_inference by fixing input size issue

### DIFF
--- a/alt_e2eshark/onnx_tests/models/hf_models.py
+++ b/alt_e2eshark/onnx_tests/models/hf_models.py
@@ -138,6 +138,11 @@ models_with_input_names_2 = {
     "hf_distilbert-base-nli-mean-tokens",
     "hf_distilbert-base-multilingual-cased",
     "hf_distilbert-base-cased",
+    "hf_ko-sroberta-multitask",
+    "hf_robertuito-sentiment-analysis",
+    "hf_sbert_large_nlu_ru",
+    "hf_sentence-bert-base-ja-mean-tokens-v2",
+
 }
 
 models_with_input_names_3 = {


### PR DESCRIPTION
Following testcases passes after fixing input issue at construct_input phase (which was causing failure at compiled_inference phase):
```
hf_ko-sroberta-multitask
hf_robertuito-sentiment-analysis
hf_sbert_large_nlu_ru
hf_sentence-bert-base-ja-mean-tokens-v2
```
