### PR TITLE
Improve verbose output of `alt_e2eshark` runner

### DIFF
--- a/alt_e2eshark/e2e_testing/backends.py
+++ b/alt_e2eshark/e2e_testing/backends.py
@@ -88,7 +88,8 @@ class SimpleIREEBackend(BackendBase):
 
 class CLIREEBackend(BackendBase):
     '''This backend calls iree through the command line to compile and run MLIR modules'''
-    def __init__(self, *, device="local-task", hal_target_backend="llvm-cpu", target_chip = None, extra_args : List[str] = None):
+    def __init__(self, *, verbose: bool, device="local-task", hal_target_backend="llvm-cpu", target_chip = None, extra_args : List[str] = None):
+        self.verbose = verbose
         self.device = device
         self.hal_target_backend = hal_target_backend
         self.target_chip = target_chip
@@ -113,7 +114,7 @@ class CLIREEBackend(BackendBase):
         # set output path
         vmfb_path = os.path.join(save_to, "compiled_model.vmfb")
         compile_command.extend(['-o', vmfb_path])
-        run_command_and_log(compile_command, save_to, "compilation")
+        run_command_and_log(compile_command, save_to, "compilation", verbose=self.verbose)
         return vmfb_path
     
     def load(self, vmfb_path: str, *, func_name=None, extra_options : RuntimeOptions):

--- a/alt_e2eshark/run.py
+++ b/alt_e2eshark/run.py
@@ -96,12 +96,14 @@ def main(args):
     if args.mode == "onnx-iree":
         pipeline = REDUCE_TO_LINALG_PIPELINE if args.torchtolinalg else []
         config = OnnxTestConfig(
-            str(TEST_DIR), SimpleIREEBackend(device=args.device, hal_target_backend=args.backend, extra_args=args.iree_compile_args), pipeline
+            str(TEST_DIR), SimpleIREEBackend(device=args.device, hal_target_backend=args.backend, extra_args=args.iree_compile_args), pipeline,
+            verbose=args.verbose
         )
     elif args.mode == "cl-onnx-iree":
         pipeline = REDUCE_TO_LINALG_PIPELINE if args.torchtolinalg else []
         config = CLOnnxTestConfig(
-            str(TEST_DIR), CLIREEBackend(device=args.device, hal_target_backend=args.backend, target_chip=args.target_chip, extra_args=args.iree_compile_args), pipeline
+            str(TEST_DIR), CLIREEBackend(verbose=args.verbose, device=args.device, hal_target_backend=args.backend, target_chip=args.target_chip, extra_args=args.iree_compile_args), pipeline,
+            verbose=args.verbose,
         )
     elif args.mode == "ort-ep":
         # TODO: allow specifying provider explicitly from cl args.


### PR DESCRIPTION
With the verbose flag on, the runner now:
- prints executed shell commands as they're run
- prints the output of failed commands

An example of what a failed test looks like now:
```
Stages to be run: ['setup', 'import_model', 'preprocessing', 'compilation', 'construct_inputs', 'native_inference', 'compiled_inference', 'postprocessing']
Test list: ['for_loop_basic']
running test for_loop_basic...
  $ python -m iree.compiler.tools.import_onnx /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.onnx --num-elements-threshold=100 --params-scope=model -o /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir
  $ iree-compile /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=host -o /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/compiled_model.vmfb
        FAILED (compilation)                    
Traceback (most recent call last):
  File "/home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/run.py", line 224, in run_tests
    compiled_artifact = config.compile(model_artifact, save_to=artifact_save_to, extra_options=options.compilation_options)
  File "/home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/e2e_testing/test_configs/onnxconfig.py", line 207, in compile
    return self.backend.compile(mlir_module, save_to=save_to, extra_options=extra_options)
  File "/home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/e2e_testing/backends.py", line 117, in compile
    run_command_and_log(compile_command, save_to, "compilation", verbose=self.verbose)
  File "/home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/e2e_testing/logging_utils.py", line 42, in run_command_and_log
    raise RuntimeError(error_msg)
RuntimeError: failure executing command:
  iree-compile /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir --iree-hal-target-backends=llvm-cpu --iree-llvmcpu-target-cpu=host -o /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/compiled_model.vmfb
Error detail in '/home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/detail/compilation.detail.log'
stderr:
  /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir:8:12: error: failed to legalize unresolved materialization from ('tensor<i64>') to ('tensor<1xi64>') that remained live after conversion
        %3 = torch.operator "onnx.Add"(%arg3, %arg1) : (!torch.vtensor<[1],si64>, !torch.vtensor<[1],si64>) -> !torch.vtensor<[1],si64> 
             ^
  /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir:8:12: note: see current operation: %9 = "builtin.unrealized_conversion_cast"(%8) : (tensor<i64>) -> tensor<1xi64>
  /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run/for_loop_basic/model.torch_onnx.mlir:8:12: note: see existing live user here: 
  %7 = linalg.generic {indexing_maps = [affine_map<(d0) -> (0)>, affine_map<(d0) -> (0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%1, %5 : tensor<1xi64>, tensor<1xi64>) outs(%6 : tensor<1xi64>) {
  ^bb0(%in: i64, %in_0: i64, %out: i64):
    %9 = arith.muli %in_0, %c1_i64 : i64
    %10 = arith.addi %in, %9 : i64
    linalg.yield %10 : i64
  } -> tensor<1xi64>


Test Summary:
        PASSES: 0
        TOTAL: 1
results stored in /home/rkayaith/repos/SHARK-TestSuite/alt_e2eshark/test-run
```